### PR TITLE
refactor: rename Tick to Pump (SUP-TICK-1)

### DIFF
--- a/crates/adapter/src/capture.rs
+++ b/crates/adapter/src/capture.rs
@@ -73,7 +73,7 @@ mod tests {
     fn rehydrate_checked_ok_when_hash_matches() {
         let event = ExternalEvent::with_payload(
             EventId::new("evt-1"),
-            ExternalEventKind::Tick,
+            ExternalEventKind::Pump,
             EventTime::from_duration(std::time::Duration::default()),
             EventPayload {
                 data: b"hello".to_vec(),
@@ -88,7 +88,7 @@ mod tests {
     fn rehydrate_checked_err_when_hash_mismatch() {
         let event = ExternalEvent::with_payload(
             EventId::new("evt-2"),
-            ExternalEventKind::Tick,
+            ExternalEventKind::Pump,
             EventTime::from_duration(std::time::Duration::default()),
             EventPayload {
                 data: b"hello".to_vec(),

--- a/crates/adapter/src/lib.rs
+++ b/crates/adapter/src/lib.rs
@@ -131,7 +131,10 @@ impl Default for EventPayload {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ExternalEventKind {
-    Tick,
+    /// Periodic event for graph evaluation cycles.
+    /// Renamed from `Tick` for domain neutrality (see TERMINOLOGY.md §9).
+    #[serde(alias = "Tick")]
+    Pump,
     DataAvailable,
     Command,
 }

--- a/crates/supervisor/src/lib.rs
+++ b/crates/supervisor/src/lib.rs
@@ -191,7 +191,7 @@ impl<L: DecisionLog, R: RuntimeInvoker> Supervisor<L, R> {
         self.clock.advance_to(event.at());
         let now = self.clock.now();
 
-        if event.kind() == ExternalEventKind::Tick {
+        if event.kind() == ExternalEventKind::Pump {
             self.process_tick(&event, now);
             return;
         }

--- a/crates/supervisor/tests/integration.rs
+++ b/crates/supervisor/tests/integration.rs
@@ -243,7 +243,7 @@ fn capturing_session_enables_round_trip_replay() {
         runtime,
     );
 
-    let event = ExternalEvent::mechanical(EventId::new("capture_event"), ExternalEventKind::Tick);
+    let event = ExternalEvent::mechanical(EventId::new("capture_event"), ExternalEventKind::Pump);
     session.on_event(event);
 
     let bundle = session.into_bundle();
@@ -352,7 +352,7 @@ fn deferred_episode_retried_on_tick() {
     // Send Tick at t=10 (after rate window expires)
     let tick = ExternalEvent::mechanical_at(
         EventId::new("tick1"),
-        ExternalEventKind::Tick,
+        ExternalEventKind::Pump,
         EventTime::from_duration(Duration::from_secs(10)),
     );
     supervisor2.on_event(tick);
@@ -383,7 +383,7 @@ fn tick_with_empty_queue_logs_noop() {
     // Send Tick with no deferred episodes
     let tick = ExternalEvent::mechanical_at(
         EventId::new("tick1"),
-        ExternalEventKind::Tick,
+        ExternalEventKind::Pump,
         EventTime::from_duration(Duration::from_secs(0)),
     );
     supervisor.on_event(tick);
@@ -456,7 +456,7 @@ fn tick_respects_episode_id_ordering() {
     // First Tick at t=10 — should invoke episode_id=1 (lower id wins tie)
     let tick1 = ExternalEvent::mechanical_at(
         EventId::new("tick1"),
-        ExternalEventKind::Tick,
+        ExternalEventKind::Pump,
         EventTime::from_duration(Duration::from_secs(10)),
     );
     supervisor.on_event(tick1);
@@ -464,7 +464,7 @@ fn tick_respects_episode_id_ordering() {
     // Second Tick at t=20 — should invoke episode_id=2
     let tick2 = ExternalEvent::mechanical_at(
         EventId::new("tick2"),
-        ExternalEventKind::Tick,
+        ExternalEventKind::Pump,
         EventTime::from_duration(Duration::from_secs(20)),
     );
     supervisor.on_event(tick2);

--- a/crates/supervisor/tests/replay_harness.rs
+++ b/crates/supervisor/tests/replay_harness.rs
@@ -10,7 +10,7 @@ use ergo_supervisor::{CaptureBundle, Constraints, Decision, EpisodeInvocationRec
 use serde_json;
 
 fn make_event_record(id: &str, at: Duration) -> ExternalEventRecord {
-    // Use Command, not Tick — Tick now has special deferred-retry behavior
+    // Use Command, not Pump — Pump has special deferred-retry behavior
     let event = ExternalEvent::mechanical_at(
         EventId::new(id.to_string()),
         ExternalEventKind::Command,
@@ -239,4 +239,27 @@ fn replay_rejects_mid_stream_corruption() {
         result,
         Err(ReplayError::HashMismatch { ref event_id }) if event_id == &EventId::new("evt-2")
     ));
+}
+
+/// RENAME-TICK-1: Old captures with "Tick" deserialize to Pump via serde alias.
+/// This ensures backward compatibility for captures created before the rename.
+#[test]
+fn legacy_tick_deserializes_to_pump() {
+    // JSON with legacy "Tick" value (simulating old capture format)
+    let legacy_json = r#"{
+        "event_id": "legacy-tick-event",
+        "event_time": { "secs": 0, "nanos": 0 },
+        "kind": "Tick",
+        "payload": [],
+        "payload_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }"#;
+
+    let record: ExternalEventRecord =
+        serde_json::from_str(legacy_json).expect("legacy Tick should deserialize");
+
+    assert_eq!(
+        record.kind,
+        ExternalEventKind::Pump,
+        "legacy 'Tick' must deserialize to Pump variant"
+    );
 }

--- a/docs/CANONICAL/TERMINOLOGY.md
+++ b/docs/CANONICAL/TERMINOLOGY.md
@@ -142,7 +142,7 @@ The following terms have trading connotations and should be avoided or renamed i
 
 | Term     | Status             | Replacement | Notes                                                                    |
 |----------|--------------------| ------------|--------------------------------------------------------------------------|
-| `Tick`   | **Rename pending** | `Pump`      | "Tick" implies market data; "Pump" is domain-neutral for periodic events |
+| `Tick`   | **Completed**      | `Pump`      | "Tick" implies market data; "Pump" is domain-neutral for periodic events |
 | `Filled` | **Rename pending** | `Completed` | "Filled" implies order execution; "Completed" is generic                 |
 
 ### Naming Rule
@@ -152,12 +152,14 @@ When adding new types, events, or concepts to core layers:
 2. If not, choose a domain-neutral alternative
 3. Vertical-specific terminology belongs in vertical crates, not core
 
+This is a review tripwire, not a linter rule; exceptions require explicit justification in the PR description. If a domain-loaded term is already serialized, renames must include backward-compat aliases and tests.
+
 ### Current Status
 
-- `ExternalEventKind::Tick` → `ExternalEventKind::Pump` (pending)
+- `ExternalEventKind::Tick` → `ExternalEventKind::Pump` (**completed**, serde alias retained)
 - `RunTermination::Filled` → `RunTermination::Completed` (pending)
 
-These renames are tracked but not yet implemented. Tests in `replay_harness.rs` already use `Command` instead of `Tick` to avoid coupling to the deferred-retry behavior.
+The `Tick` → `Pump` rename is complete with backward-compatible `#[serde(alias = "Tick")]`. Test `legacy_tick_deserializes_to_pump` verifies old captures remain replayable.
 
 ---
 


### PR DESCRIPTION
## Summary
- Rename `ExternalEventKind::Tick` → `Pump` for domain neutrality
- Add `#[serde(alias = "Tick")]` for backward-compatible deserialization
- Update all code references in adapter, supervisor, and tests
- Add `legacy_tick_deserializes_to_pump` test for backward compat verification

## Files Changed
| File | Changes |
|------|---------|
| `crates/adapter/src/lib.rs` | Rename variant, add serde alias |
| `crates/adapter/src/capture.rs` | Update references |
| `crates/supervisor/src/lib.rs` | Update references |
| `crates/supervisor/tests/integration.rs` | Update test references |
| `crates/supervisor/tests/replay_harness.rs` | Update comment, add backward compat test |
| `docs/CANONICAL/TERMINOLOGY.md` | Mark Tick→Pump complete, add review/serialization rules |

## Test plan
- [x] `cargo test --workspace` passes (12/12 replay_harness tests)
- [x] `grep -rn "::Tick" crates/` returns zero matches
- [x] Serde alias `#[serde(alias = "Tick")]` present on `Pump` variant
- [x] `legacy_tick_deserializes_to_pump` test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)