### PR TITLE
refactor(runtime): rename Filled to Completed (RENAME-FILLED-1)

### DIFF
--- a/crates/runtime/src/action/implementations/ack/impl.rs
+++ b/crates/runtime/src/action/implementations/ack/impl.rs
@@ -48,7 +48,7 @@ impl ActionPrimitive for AckAction {
             .unwrap_or(true);
 
         let outcome = if accept {
-            ActionOutcome::Filled
+            ActionOutcome::Completed
         } else {
             ActionOutcome::Rejected
         };

--- a/crates/runtime/src/action/mod.rs
+++ b/crates/runtime/src/action/mod.rs
@@ -20,7 +20,9 @@ pub enum ActionValueType {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ActionOutcome {
     Attempted,
-    Filled,
+    /// Action executed successfully and completed.
+    /// NOTE: If serialization is introduced, add backward-compat serde alias for legacy "Filled".
+    Completed,
     Rejected,
     Cancelled,
     Failed,

--- a/crates/runtime/src/action/tests.rs
+++ b/crates/runtime/src/action/tests.rs
@@ -20,7 +20,7 @@ fn ack_action_respects_accept_parameter() {
     );
     assert_eq!(
         accepted.get("outcome"),
-        Some(&ActionValue::Event(ActionOutcome::Filled))
+        Some(&ActionValue::Event(ActionOutcome::Completed))
     );
 
     let rejected = action.execute(

--- a/crates/runtime/src/runtime/tests.rs
+++ b/crates/runtime/src/runtime/tests.rs
@@ -441,7 +441,7 @@ fn hello_world_graph_executes_with_core_catalog_and_registries() {
     assert_eq!(
         report.outputs.get("action_outcome"),
         Some(&RuntimeValue::Event(
-            crate::runtime::types::RuntimeEvent::Action(crate::action::ActionOutcome::Filled)
+            crate::runtime::types::RuntimeEvent::Action(crate::action::ActionOutcome::Completed)
         ))
     );
 }
@@ -728,7 +728,7 @@ fn r7_action_skipped_when_trigger_not_emitted() {
 
     let report = run(&expanded, &catalog, &registries, &ctx).unwrap();
 
-    // R.7 enforcement: Action should be Skipped, not Attempted/Filled
+    // R.7 enforcement: Action should be Skipped, not Attempted/Completed
     assert_eq!(
         report.outputs.get("action_outcome"),
         Some(&RuntimeValue::Event(

--- a/crates/supervisor/tests/integration.rs
+++ b/crates/supervisor/tests/integration.rs
@@ -46,7 +46,7 @@ impl DecisionLog for CapturingLog {
 /// Structure: number_source(3.0) -> gt <- number_source(1.0)
 ///            gt:result -> emit_if_true:input
 ///            emit_if_true:event -> ack_action:event
-/// Since 3.0 > 1.0, trigger emits, action executes with outcome Filled.
+/// Since 3.0 > 1.0, trigger emits, action executes with outcome Completed.
 fn build_hello_world_graph() -> ExpandedGraph {
     let mut nodes = HashMap::new();
 

--- a/crates/ui-authoring/src/examples/helloWorld.ts
+++ b/crates/ui-authoring/src/examples/helloWorld.ts
@@ -9,7 +9,7 @@
  *   gt.result → emit_if_true.input
  *   emit_if_true.event → ack_action.event
  *
- * Expected result: action_outcome = Event(Action(Filled))
+ * Expected result: action_outcome = Event(Action(Completed))
  */
 
 import {

--- a/docs/CANONICAL/TERMINOLOGY.md
+++ b/docs/CANONICAL/TERMINOLOGY.md
@@ -143,7 +143,7 @@ The following terms have trading connotations and should be avoided or renamed i
 | Term     | Status             | Replacement | Notes                                                                    |
 |----------|--------------------| ------------|--------------------------------------------------------------------------|
 | `Tick`   | **Completed**      | `Pump`      | "Tick" implies market data; "Pump" is domain-neutral for periodic events |
-| `Filled` | **Rename pending** | `Completed` | "Filled" implies order execution; "Completed" is generic                 |
+| `Filled` | **Completed**      | `Completed` | "Filled" implies order execution; "Completed" is generic                 |
 
 ### Naming Rule
 
@@ -157,9 +157,11 @@ This is a review tripwire, not a linter rule; exceptions require explicit justif
 ### Current Status
 
 - `ExternalEventKind::Tick` → `ExternalEventKind::Pump` (**completed**, serde alias retained)
-- `RunTermination::Filled` → `RunTermination::Completed` (pending)
+- `ActionOutcome::Filled` → `ActionOutcome::Completed` (**completed**, not serialized)
 
 The `Tick` → `Pump` rename is complete with backward-compatible `#[serde(alias = "Tick")]`. Test `legacy_tick_deserializes_to_pump` verifies old captures remain replayable.
+
+The `Filled` → `Completed` rename is complete. `ActionOutcome` is not serialized, so no backward-compat alias needed. Doc comment notes alias requirement if serialization is added.
 
 ---
 

--- a/docs/CONTRACTS/UI_RUNTIME_CONTRACT.md
+++ b/docs/CONTRACTS/UI_RUNTIME_CONTRACT.md
@@ -204,7 +204,7 @@ Boundary outputs:
 |----------------|---------------|
 | action_outcome | act:outcome   |
 
-Result: `action_outcome = Event(Action(Filled))`
+Result: `action_outcome = Event(Action(Completed))`
 
 ---
 

--- a/docs/closure_register.md
+++ b/docs/closure_register.md
@@ -239,6 +239,19 @@ Legend:
 
 ---
 
+### RENAME-FILLED-1 — ActionOutcome::Filled renamed to Completed
+
+- **ID:** RENAME-FILLED-1
+- **Change:** `ActionOutcome::Filled` → `ActionOutcome::Completed`
+- **Rationale:** Domain neutrality (TERMINOLOGY.md §9). "Filled" implies order execution; "Completed" is generic.
+- **Disposition:** CLOSE
+- **Enforcement locus:** `crates/runtime/src/action/mod.rs`
+- **Serialization:** Not currently serialized. Doc comment added for future alias requirement.
+- **Test:** Existing `ack_action_respects_accept_parameter` and `hello_world_graph_produces_expected_outputs` verify Completed outcome.
+- **PR/Commit:** 6bf4596
+
+---
+
 ## Semantics Decision Queue (v1)
 
 ### B.2 — Divide-by-zero behavior


### PR DESCRIPTION
- Rename-only, domain-neutrality compliance
- No serialization surface introduced
- closure_register.md entry included
- Workspace tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)