### PR TITLE
doc(ui): reframe ui-authoring as reference client (UI-REF-CLIENT-1)

### DIFF
--- a/docs/CANONICAL/PHASE_INVARIANTS.md
+++ b/docs/CANONICAL/PHASE_INVARIANTS.md
@@ -431,6 +431,19 @@ additional capture mechanism is required.
 - **REP-SCOPE:** Replay determinism covers supervisor scheduling decisions only. It does not capture or replay the internal execution of the runtime graph. Source outputs, compute results, and action side effects are not recorded. Replay verifies that given the same external events, the supervisor makes identical scheduling decisions.
 - **SOURCE-TRUST:** Source primitive determinism is trust-based, not enforced. The `SourcePrimitiveManifest` declares `execution.deterministic = true`, but the trait has no compile-time restrictions preventing non-deterministic implementations. Enforcement is by convention and code review. See `source/registry.rs::validate_manifest()`.
 
+### UI-REF-CLIENT-1: UI Authoring is Non-Canonical
+
+**Status:** Documented
+**Enforcement:** Convention
+
+The `crates/ui-authoring` crate is a **reference client** demonstrating how to construct and emit `ExpandedGraph` payloads. It is NOT:
+
+- A canonical contract implementation
+- An enforcement boundary
+- A required dependency for runtime execution
+
+Contract authority remains with Rust types + `UI_RUNTIME_CONTRACT.md`. TypeScript types are best-effort mirrors.
+
 ---
 
 ## Supervisor + Replay Freeze Declaration
@@ -533,3 +546,4 @@ Changes to this document require the same review bar as changes to frozen specs.
 | v0.17 | 2025-01-05 | Claude Code | X.11 added: guard Int→f64 conversion for exact representability (Codex audit finding) |
 | v0.18 | 2025-01-05 | Claude Code | REP-1 strengthened: point-of-use hash verification in supervisor replay path (REP-1b) |
 | v0.19 | 2025-01-05 | Claude Code | Added SUP-TICK-1, RTHANDLE-ID-1 (orchestration); REP-SCOPE, SOURCE-TRUST (replay scope/trust documentation) |
+| v0.20 | 2026-01-05 | Claude Code | Added UI-REF-CLIENT-1: ui-authoring reframed as reference client |

--- a/docs/CONTRACTS/UI_RUNTIME_CONTRACT.md
+++ b/docs/CONTRACTS/UI_RUNTIME_CONTRACT.md
@@ -1,13 +1,24 @@
 ---
 Authority: CONTRACTS
 Version: v0
-Last Updated: 2025-12-22
+Last Updated: 2026-01-05
 Derived From: src/runtime/tests.rs::hello_world_graph_executes_with_core_catalog_and_registries
 ---
 
 # UI ↔ Runtime Contract
 
 This document defines the exact data structure a UI must emit to drive the Primitive Library runtime.
+
+---
+
+## Trust Boundary Notice
+
+**`crates/ui-authoring` is a Reference Client, not a canonical contract implementation.**
+
+- **Authority:** Runtime contract authority is Rust types in `crates/runtime/src/cluster.rs` + this document
+- **TypeScript mirror:** `contractTypes.ts` is a best-effort mirror; not enforcement
+- **No guarantees:** Reference UI may have conveniences (e.g., default values, loose typing) that a production client must not rely on
+- **Validation:** All contract enforcement happens at runtime; UI-side validation is advisory only
 
 ---
 

--- a/docs/closure_register.md
+++ b/docs/closure_register.md
@@ -252,6 +252,37 @@ Legend:
 
 ---
 
+## UI-REF-CLIENT-1
+
+**Date:** 2026-01-05
+**Status:** CLOSED
+**Category:** Trust Boundary Clarification
+
+### Finding
+
+`crates/ui-authoring` was implicitly treated as a canonical contract implementation. Audit revealed:
+
+- TypeScript types are incomplete (InputPortSpec, RuntimeEvent)
+- No TypeScript type checking (missing tsconfig.json)
+- Reference client conveniences should not be relied upon by production clients
+
+### Resolution
+
+Reframe as **Reference Client**:
+
+- Runtime contract authority is Rust types + UI_RUNTIME_CONTRACT.md
+- TypeScript mirror is best-effort, not enforcement
+- UI-side validation is advisory only
+
+### v1 Tracking
+
+- UI-TSCHECK-1: Add tsconfig.json
+- UI-CONTRACT-ALIGN-1: Fix TS contract drift
+- UI-COERCION-1: Remove Inspector silent fallbacks
+- UI-INT-GUARD-1: Add Int range guards
+
+---
+
 ## Semantics Decision Queue (v1)
 
 ### B.2 — Divide-by-zero behavior


### PR DESCRIPTION
## Summary

- Add Trust Boundary Notice to UI_RUNTIME_CONTRACT.md
- Add UI-REF-CLIENT-1 invariant to PHASE_INVARIANTS.md  
- Add UI-REF-CLIENT-1 closure to closure_register.md

## Context

The UI-authoring ↔ Runtime Contract Audit revealed that `crates/ui-authoring` was implicitly treated as a canonical contract implementation. This PR clarifies:

- **Authority:** Runtime contract authority is Rust types in `crates/runtime/src/cluster.rs` + `UI_RUNTIME_CONTRACT.md`
- **TypeScript mirror:** `contractTypes.ts` is a best-effort mirror; not enforcement
- **No guarantees:** Reference UI may have conveniences that production clients must not rely on
- **Validation:** All contract enforcement happens at runtime; UI-side validation is advisory only

## Files Changed

| File | Change |
|------|--------|
| `docs/CONTRACTS/UI_RUNTIME_CONTRACT.md` | Added Trust Boundary Notice section |
| `docs/CANONICAL/PHASE_INVARIANTS.md` | Added UI-REF-CLIENT-1 invariant + revision history |
| `docs/closure_register.md` | Added UI-REF-CLIENT-1 closure with v1 tracking items |

## Test plan

- [x] Docs-only change — no code modified
- [x] `cargo test --workspace` should pass (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)