### PR TITLE
fix(adapter): harden rehydrate visibility + add Pump serde test

### DIFF
--- a/crates/adapter/src/capture.rs
+++ b/crates/adapter/src/capture.rs
@@ -32,7 +32,10 @@ impl ExternalEventRecord {
 
     /// Reconstructs an ExternalEvent without validating payload integrity.
     /// Prefer `rehydrate_checked()` in replay paths.
-    pub fn rehydrate(&self) -> ExternalEvent {
+    ///
+    /// This is `pub(crate)` to prevent external callers from bypassing
+    /// hash validation. See HARDEN-REHYDRATE-1.
+    pub(crate) fn rehydrate(&self) -> ExternalEvent {
         ExternalEvent::with_payload(
             self.event_id.clone(),
             self.kind,

--- a/crates/adapter/src/lib.rs
+++ b/crates/adapter/src/lib.rs
@@ -379,4 +379,19 @@ mod tests {
         let term = handle.run(&GraphId::new("g"), &EventId::new("e1"), &ctx, None);
         assert_eq!(term, RunTermination::Completed);
     }
+
+    /// TEST-PUMP-SERDE-1: Verify Pump serializes as "Pump" not "Tick".
+    /// The serde(alias = "Tick") allows deserialization of legacy data,
+    /// but serialization must produce the canonical name.
+    #[test]
+    fn pump_serializes_as_pump_not_tick() {
+        let serialized = serde_json::to_string(&ExternalEventKind::Pump).unwrap();
+        assert_eq!(serialized, "\"Pump\"", "Pump must serialize as 'Pump', not legacy 'Tick'");
+
+        // Also verify the alias still works for deserialization (backward compat)
+        let from_pump: ExternalEventKind = serde_json::from_str("\"Pump\"").unwrap();
+        let from_tick: ExternalEventKind = serde_json::from_str("\"Tick\"").unwrap();
+        assert_eq!(from_pump, ExternalEventKind::Pump);
+        assert_eq!(from_tick, ExternalEventKind::Pump);
+    }
 }


### PR DESCRIPTION
## Summary

- Make `ExternalEventRecord::rehydrate()` `pub(crate)` to prevent external bypass of hash validation
- Add explicit test for `ExternalEventKind::Pump` serialization

## Closes

- #12 HARDEN-REHYDRATE-1
- #13 TEST-PUMP-SERDE-1

## Changes

### #12: rehydrate() visibility hardening

`rehydrate()` reconstructs an `ExternalEvent` without validating payload integrity. Previously `pub`, now `pub(crate)`.

- Only internal caller: `rehydrate_checked()` (which validates hash first)
- Verified with `rg "\.rehydrate\(\)" --type rust` — no external callers

### #13: Pump serialization test

Added test verifying:
- `ExternalEventKind::Pump` serializes as `"Pump"` (not legacy `"Tick"`)
- Backward compat: `"Tick"` still deserializes to `Pump` via `#[serde(alias)]`

## Test plan

- [x] `cargo test --workspace` passes
- [x] New test `pump_serializes_as_pump_not_tick` verifies serde behavior
- [x] No external callers of `rehydrate()` exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)