### PR TITLE
chore(ui-authoring): add tsconfig.json for type checking

### DIFF
--- a/crates/ui-authoring/tsconfig.json
+++ b/crates/ui-authoring/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist", "build"]
+}


### PR DESCRIPTION
## Summary

Add `tsconfig.json` to enable TypeScript type checking for the UI reference client.

## Closes

- #16 UI-TSCHECK-1

## Changes

Added `tsconfig.json` with strict mode:
- `strict: true`
- `noUncheckedIndexedAccess: true`
- `noImplicitReturns: true`
- `noFallthroughCasesInSwitch: true`

## Note on exactOptionalPropertyTypes

Deliberately omitted `exactOptionalPropertyTypes` for now. Enabling it reveals contract alignment issues that will be fixed in PR3 (#17-19):
- `adapter.ts:99` - optional property assignment
- `RunPanel.tsx:33` - location type mismatch

Once those are fixed, we can enable this stricter option.

## Test plan

- [x] `npm run typecheck` passes
- [x] `cargo test --workspace` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)