### PR TITLE
docs(runtime): document divide-by-zero semantics gap (B.2)

### DIFF
--- a/crates/runtime/src/compute/implementations/divide/impl.rs
+++ b/crates/runtime/src/compute/implementations/divide/impl.rs
@@ -43,6 +43,11 @@ impl ComputePrimitive for Divide {
             .and_then(|v| v.as_number())
             .expect("missing required numeric input 'b'");
 
+        // TODO(B.2): IEEE 754 divide-by-zero produces inf/-inf/NaN, not an error.
+        // Risks: NaN propagates silently; NaN comparisons are non-deterministic
+        // for replay; downstream branching on NaN may diverge across runs.
+        // Decision deferred to v1: either "structured error on divisor==0"
+        // vs "allow IEEE + canonicalization rules". See issue #7.
         HashMap::from([("result".to_string(), Value::Number(a / b))])
     }
 }

--- a/docs/closure_register.md
+++ b/docs/closure_register.md
@@ -318,6 +318,12 @@ Reframe as **Reference Client**:
 ### B.2 — Divide-by-zero behavior
 - **ID:** B.2
 - **Current behavior:** IEEE 754 propagation (`inf`, `-inf`, `NaN`)
-- **Disposition:** V1 SEMANTICS
-- **Decision needed:** Document IEEE 754 as acceptable in v0 vs. add explicit zero-check with typed error in v1 (semantics change)
-- **PR/Commit:** <pending / doc note optional>
+- **Location:** `crates/runtime/src/compute/implementations/divide/impl.rs` (see `TODO(B.2)`)
+- **Disposition:** V1 SEMANTICS — no v0 change
+- **Risks:**
+  - NaN propagates silently through downstream computations
+  - NaN comparisons are non-deterministic (`NaN != NaN`), affecting replay fidelity
+  - Downstream branching on NaN may diverge across runs
+- **Decision needed (v1):** Either "structured error on divisor==0" vs "allow IEEE + canonicalization rules"
+- **Tracking:** Issue #7
+- **PR/Commit:** docs-only marker added


### PR DESCRIPTION
## Summary
- Add `TODO(B.2)` marker at divide implementation documenting IEEE 754 behavior and replay risks
- Expand closure_register.md B.2 entry with risk details, code location, and issue reference

**No functional changes** - IEEE 754 behavior preserved.

**Does NOT close #7** - issue remains open for v1 semantics decision.

## Risks documented
- NaN propagates silently through downstream computations
- NaN comparisons are non-deterministic (`NaN != NaN`), affecting replay fidelity
- Downstream branching on NaN may diverge across runs

## Test plan
- [x] `cargo fmt && cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)