### PR TITLE
docs: pin payload contract + enforce default behavior tests

### DIFF
--- a/crates/runtime/README.md
+++ b/crates/runtime/README.md
@@ -22,9 +22,48 @@ It is NOT:
 Downstream systems depend on this library.
 This library depends on nothing downstream.
 
+## Payload Contract (v0)
+
+### Context Value Access
+
+Sources may read values from `ExecutionContext` via the `value(key)` method. The context is populated from event payloads by the adapter layer.
+
+### Behavior
+
+| Condition | Behavior |
+|-----------|----------|
+| Key exists, correct type | Returns value |
+| Key missing | Returns type-specific default (0.0 for numbers) |
+| Key exists, wrong type | Returns type-specific default (0.0 for numbers) |
+
+### Supported Types
+
+| Type | Default | Access Pattern |
+|------|---------|----------------|
+| Number (f64) | 0.0 | `ctx.value(key).and_then(\|v\| v.as_number())` |
+
+### Payload Hydration Path
+
+```
+ExternalEvent::with_payload()
+    → context_from_payload()
+    → payload_values() [JSON → Value]
+    → RuntimeExecutionContext::from_values()
+    → Source::produce(&params, &ctx)
+```
+
+### Key Naming
+
+Context keys are strings. Current implementations:
+- `context_number_source`: reads key `"x"`
+
+### Determinism
+
+All default behaviors are deterministic. Missing or malformed payload data produces consistent outputs across replay.
+
 ## Core stdlib wiring
 
-- Sources: `number_source`, `boolean_source`
+- Sources: `number_source`, `boolean_source`, `string_source`, `context_number_source`
 - Computes: `const_number`, `const_bool`, `add`, `subtract`, `multiply`, `divide`, `negate`, `gt`, `lt`, `eq`, `neq`, `and`, `or`, `not`, `select`
 - Trigger: `emit_if_true`
 - Actions: `ack_action`, `annotate_action`

--- a/crates/runtime/src/source/tests.rs
+++ b/crates/runtime/src/source/tests.rs
@@ -79,3 +79,29 @@ fn context_number_source_reads_context_value() {
     let outputs = source.produce(&HashMap::new(), &ctx);
     assert_eq!(outputs.get("value"), Some(&Value::Number(9.5)));
 }
+
+#[test]
+fn context_number_source_missing_key_returns_default() {
+    let source = ContextNumberSource::new();
+    // Context has no "x" key
+    let ctx = ExecutionContext::from_values(HashMap::from([(
+        "other_key".to_string(),
+        Value::Number(99.0),
+    )]));
+
+    let outputs = source.produce(&HashMap::new(), &ctx);
+    assert_eq!(outputs.get("value"), Some(&Value::Number(0.0)));
+}
+
+#[test]
+fn context_number_source_wrong_type_returns_default() {
+    let source = ContextNumberSource::new();
+    // Context has "x" key but wrong type (String instead of Number)
+    let ctx = ExecutionContext::from_values(HashMap::from([(
+        "x".to_string(),
+        Value::String("not a number".to_string()),
+    )]));
+
+    let outputs = source.produce(&HashMap::new(), &ctx);
+    assert_eq!(outputs.get("value"), Some(&Value::Number(0.0)));
+}


### PR DESCRIPTION
## Summary

Pins the payload contract after PR #31 merged. Documents ExecutionContext value access behavior and adds tests to enforce it.

### What Changed
- Documents missing-key and type-mismatch default behavior
- Adds enforcement tests for context_number_source defaults
- Updates stdlib wiring list to include all sources

---

## Invariant Mapping

### ✅ Invariants now enforced
- **CXT-1** — Payload access behavior now documented and tested

### Notes
- No runtime behavior changes — tests verify existing behavior
- Prevents future drift by making defaults explicit

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)