### PR TITLE
feat(adapter): add file adapter wrapper

### DIFF
--- a/crates/adapter/src/fixture.rs
+++ b/crates/adapter/src/fixture.rs
@@ -1,0 +1,80 @@
+use std::fs;
+use std::io::{self, BufRead};
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::ExternalEventKind;
+
+#[derive(Debug, Clone)]
+pub enum FixtureItem {
+    EpisodeStart {
+        label: String,
+    },
+    Event {
+        id: Option<String>,
+        kind: ExternalEventKind,
+        payload: Option<serde_json::Value>,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum FixtureRecord {
+    EpisodeStart { id: Option<String> },
+    Event { event: FixtureEvent },
+}
+
+#[derive(Debug, Deserialize)]
+struct FixtureEvent {
+    #[serde(rename = "type")]
+    kind: ExternalEventKind,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    payload: Option<serde_json::Value>,
+}
+
+pub fn parse_fixture(path: &Path) -> Result<Vec<FixtureItem>, String> {
+    let file = fs::File::open(path).map_err(|err| format!("read fixture: {err}"))?;
+    let reader = io::BufReader::new(file);
+    let mut items = Vec::new();
+    let mut episode_counter = 0usize;
+
+    for (index, line) in reader.lines().enumerate() {
+        let line = line.map_err(|err| format!("read fixture line {}: {err}", index + 1))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let record: FixtureRecord = serde_json::from_str(trimmed)
+            .map_err(|err| format!("fixture parse error at line {}: {err}", index + 1))?;
+
+        match record {
+            FixtureRecord::EpisodeStart { id } => {
+                episode_counter += 1;
+                let label = id.unwrap_or_else(|| format!("E{}", episode_counter));
+                items.push(FixtureItem::EpisodeStart { label });
+            }
+            FixtureRecord::Event { event } => {
+                items.push(FixtureItem::Event {
+                    id: event.id,
+                    kind: event.kind,
+                    payload: event.payload,
+                });
+            }
+        }
+    }
+
+    Ok(items)
+}
+
+pub fn fixture_output_path(path: &Path) -> PathBuf {
+    let stem = path
+        .file_stem()
+        .map(|s| s.to_string_lossy())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "fixture".into());
+    PathBuf::from("target").join(format!("{stem}-replay.json"))
+}

--- a/crates/adapter/src/lib.rs
+++ b/crates/adapter/src/lib.rs
@@ -10,6 +10,7 @@ use ergo_runtime::runtime::Registries;
 use serde::{Deserialize, Serialize};
 
 pub mod capture;
+pub mod fixture;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]

--- a/crates/ergo-cli/src/main.rs
+++ b/crates/ergo-cli/src/main.rs
@@ -1,47 +1,23 @@
 use std::collections::HashMap;
 use std::fs;
-use std::io::{self, BufRead};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use ergo_adapter::fixture;
 use ergo_adapter::{
-    EventId, EventPayload, EventTime, ExternalEvent, ExternalEventKind, GraphId, RuntimeHandle,
+    EventId, EventPayload, ExternalEvent, ExternalEventKind, GraphId, RuntimeHandle,
 };
 use ergo_runtime::action::ActionOutcome;
 use ergo_runtime::catalog::{build_core_catalog, core_registries};
 use ergo_supervisor::demo::demo_1;
+use ergo_supervisor::fixture_runner;
 use ergo_supervisor::replay::replay_checked;
 use ergo_supervisor::{
     CaptureBundle, CapturingSession, Constraints, Decision, DecisionLog, DecisionLogEntry,
-    EpisodeInvocationRecord,
 };
-use serde::Deserialize;
 
 const DEMO_GRAPH_ID: &str = "demo_1";
 const DEFAULT_REPLAY_PATH: &str = "target/demo-1-replay.json";
-
-#[derive(Debug)]
-struct EpisodeInfo {
-    label: String,
-    event_ids: Vec<String>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-enum FixtureRecord {
-    EpisodeStart { id: Option<String> },
-    Event { event: FixtureEvent },
-}
-
-#[derive(Debug, Deserialize)]
-struct FixtureEvent {
-    #[serde(rename = "type")]
-    kind: ExternalEventKind,
-    #[serde(default)]
-    id: Option<String>,
-    #[serde(default)]
-    payload: Option<serde_json::Value>,
-}
 
 struct NullLog;
 
@@ -97,6 +73,11 @@ fn usage() -> String {
     .join("\n")
 }
 
+fn load_bundle(path: &Path) -> Result<CaptureBundle, String> {
+    let data = fs::read_to_string(path).map_err(|err| format!("read replay artifact: {err}"))?;
+    serde_json::from_str(&data).map_err(|err| format!("parse replay artifact: {err}"))
+}
+
 fn write_replay_artifact(path: &Path, bundle: &CaptureBundle) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|err| format!("create replay directory: {err}"))?;
@@ -106,20 +87,6 @@ fn write_replay_artifact(path: &Path, bundle: &CaptureBundle) -> Result<(), Stri
         .map_err(|err| format!("serialize replay bundle: {err}"))?;
     fs::write(path, format!("{data}\n")).map_err(|err| format!("write replay artifact: {err}"))?;
     Ok(())
-}
-
-fn load_bundle(path: &Path) -> Result<CaptureBundle, String> {
-    let data = fs::read_to_string(path).map_err(|err| format!("read replay artifact: {err}"))?;
-    serde_json::from_str(&data).map_err(|err| format!("parse replay artifact: {err}"))
-}
-
-fn fixture_output_path(path: &Path) -> PathBuf {
-    let stem = path
-        .file_stem()
-        .map(|s| s.to_string_lossy())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "fixture".into());
-    PathBuf::from("target").join(format!("{stem}-replay.json"))
 }
 
 fn run_demo_1() -> Result<(), String> {
@@ -168,163 +135,28 @@ fn run_fixture(path: &Path, output_override: Option<&Path>) -> Result<PathBuf, S
     let core_registries =
         Arc::new(core_registries().map_err(|err| format!("core registries: {err:?}"))?);
 
-    let runtime = RuntimeHandle::new(graph.clone(), catalog.clone(), core_registries.clone());
-    let mut session = CapturingSession::new(
-        GraphId::new(DEMO_GRAPH_ID),
-        Constraints::default(),
-        NullLog,
-        runtime,
-    );
-
-    let file = fs::File::open(path).map_err(|err| format!("read fixture: {err}"))?;
-    let reader = io::BufReader::new(file);
-    let mut episodes: Vec<EpisodeInfo> = Vec::new();
-    let mut current_episode: Option<usize> = None;
-    let mut event_counter = 0usize;
-    let mut context_by_event: HashMap<String, Option<f64>> = HashMap::new();
-
-    for (index, line) in reader.lines().enumerate() {
-        let line = line.map_err(|err| format!("read fixture line {}: {err}", index + 1))?;
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        let record: FixtureRecord = serde_json::from_str(trimmed)
-            .map_err(|err| format!("fixture parse error at line {}: {err}", index + 1))?;
-
-        match record {
-            FixtureRecord::EpisodeStart { id } => {
-                let label = id.unwrap_or_else(|| format!("E{}", episodes.len() + 1));
-                episodes.push(EpisodeInfo {
-                    label,
-                    event_ids: Vec::new(),
-                });
-                current_episode = Some(episodes.len() - 1);
-            }
-            FixtureRecord::Event { event } => {
-                if current_episode.is_none() {
-                    let label = format!("E{}", episodes.len() + 1);
-                    episodes.push(EpisodeInfo {
-                        label,
-                        event_ids: Vec::new(),
-                    });
-                    current_episode = Some(episodes.len() - 1);
-                }
-
-                event_counter += 1;
-                let event_id = event
-                    .id
-                    .unwrap_or_else(|| format!("fixture_evt_{}", event_counter));
-                let context_value = event.payload.as_ref().and_then(context_value_from_json);
-                let external = match event.payload {
-                    Some(payload) => {
-                        let data = serde_json::to_vec(&payload).map_err(|err| {
-                            format!("fixture payload encode error at line {}: {err}", index + 1)
-                        })?;
-                        ExternalEvent::with_payload(
-                            EventId::new(event_id.clone()),
-                            event.kind,
-                            EventTime::default(),
-                            EventPayload { data },
-                        )
-                    }
-                    None => ExternalEvent::mechanical(EventId::new(event_id.clone()), event.kind),
-                };
-                context_by_event.insert(event_id.clone(), context_value);
-                session.on_event(external);
-
-                let episode_index = current_episode.expect("episode index set");
-                episodes[episode_index].event_ids.push(event_id);
-            }
-        }
-    }
-
-    if episodes.is_empty() {
-        return Err("fixture contained no episodes".to_string());
-    }
-
-    if episodes.iter().all(|episode| episode.event_ids.is_empty()) {
-        return Err("fixture contained no events".to_string());
-    }
-
-    if let Some(episode) = episodes.iter().find(|episode| episode.event_ids.is_empty()) {
-        return Err(format!("episode '{}' has no events", episode.label));
-    }
-
-    let bundle = session.into_bundle();
-    print_fixture_summaries(&episodes, &bundle.decisions, &context_by_event)?;
-
-    let artifact_path = output_override
+    let items =
+        fixture::parse_fixture(path).map_err(|err| format!("Failed to parse fixture: {err}"))?;
+    let output_path = output_override
         .map(PathBuf::from)
-        .unwrap_or_else(|| fixture_output_path(path));
-    write_replay_artifact(&artifact_path, &bundle)?;
-    println!("replay artifact: {}", artifact_path.display());
-    Ok(artifact_path)
-}
+        .unwrap_or_else(|| fixture::fixture_output_path(path));
+    let result =
+        fixture_runner::run_fixture(items, graph, catalog, core_registries, Some(output_path))?;
 
-fn print_fixture_summaries(
-    episodes: &[EpisodeInfo],
-    decisions: &[EpisodeInvocationRecord],
-    context_by_event: &HashMap<String, Option<f64>>,
-) -> Result<(), String> {
-    let mut decisions_by_event: HashMap<String, Vec<Decision>> = HashMap::new();
-    for record in decisions {
-        decisions_by_event
-            .entry(record.event_id.as_str().to_string())
-            .or_default()
-            .push(record.decision);
-    }
-
-    for episode in episodes {
-        let mut invoked = false;
-        let mut deferred = false;
-        let mut invoked_event: Option<&String> = None;
-
-        for event_id in &episode.event_ids {
-            let entries = decisions_by_event
-                .get(event_id)
-                .ok_or_else(|| format!("no decision for event '{event_id}'"))?;
-            if entries.iter().any(|decision| *decision == Decision::Invoke) {
-                invoked = true;
-                if invoked_event.is_none() {
-                    invoked_event = Some(event_id);
-                }
-            }
-            if entries.iter().any(|decision| *decision == Decision::Defer) {
-                deferred = true;
-            }
-        }
-
-        let decision_label = if invoked {
-            "invoke"
-        } else if deferred {
-            "defer"
-        } else {
-            "none"
-        };
-        let context_value = invoked_event
-            .and_then(|event_id| context_by_event.get(event_id))
-            .copied()
-            .flatten();
-        let summary = demo_1::summary_for_context_value(context_value);
-        let action_a_status = action_status(invoked, summary.action_a_outcome.clone());
-        let action_b_status = action_status(invoked, summary.action_b_outcome.clone());
-        let trigger_a_status = trigger_status(invoked, summary.action_a_outcome.clone());
-        let trigger_b_status = trigger_status(invoked, summary.action_b_outcome.clone());
-
+    for episode in &result.episodes {
         println!(
             "episode {}: decision={} TriggerA={} TriggerB={} ActionA={} ActionB={}",
             episode.label,
-            decision_label,
-            trigger_a_status,
-            trigger_b_status,
-            action_a_status,
-            action_b_status
+            episode.decision,
+            episode.trigger_a,
+            episode.trigger_b,
+            episode.action_a,
+            episode.action_b
         );
     }
 
-    Ok(())
+    println!("replay artifact: {}", result.artifact_path.display());
+    Ok(result.artifact_path)
 }
 
 fn action_status(invoked: bool, outcome: ActionOutcome) -> &'static str {

--- a/crates/supervisor/src/fixture_runner.rs
+++ b/crates/supervisor/src/fixture_runner.rs
@@ -1,0 +1,260 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use ergo_adapter::fixture::FixtureItem;
+use ergo_adapter::{
+    EventId, EventPayload, EventTime, ExternalEvent, ExternalEventKind, GraphId, RuntimeHandle,
+};
+use ergo_runtime::action::ActionOutcome;
+use ergo_runtime::catalog::{CorePrimitiveCatalog, CoreRegistries};
+use ergo_runtime::cluster::ExpandedGraph;
+
+use crate::demo::demo_1;
+use crate::{
+    CaptureBundle, CapturingSession, Constraints, Decision, DecisionLog, DecisionLogEntry,
+};
+
+const DEFAULT_GRAPH_ID: &str = "demo_1";
+const DEFAULT_ARTIFACT_NAME: &str = "fixture-replay.json";
+
+#[derive(Debug, Clone)]
+pub struct EpisodeSummary {
+    pub label: String,
+    pub decision: String,
+    pub trigger_a: String,
+    pub trigger_b: String,
+    pub action_a: String,
+    pub action_b: String,
+}
+
+#[derive(Debug)]
+pub struct FixtureRunResult {
+    pub artifact_path: PathBuf,
+    pub episodes: Vec<EpisodeSummary>,
+}
+
+struct NullLog;
+
+impl DecisionLog for NullLog {
+    fn log(&self, _entry: DecisionLogEntry) {}
+}
+
+#[derive(Debug)]
+struct EpisodeInfo {
+    label: String,
+    event_ids: Vec<String>,
+}
+
+pub fn run_fixture(
+    items: Vec<FixtureItem>,
+    graph: Arc<ExpandedGraph>,
+    catalog: Arc<CorePrimitiveCatalog>,
+    registries: Arc<CoreRegistries>,
+    output_path: Option<PathBuf>,
+) -> Result<FixtureRunResult, String> {
+    let runtime = RuntimeHandle::new(graph, catalog, registries);
+    let mut session = CapturingSession::new(
+        GraphId::new(DEFAULT_GRAPH_ID),
+        Constraints::default(),
+        NullLog,
+        runtime,
+    );
+
+    let mut episodes: Vec<EpisodeInfo> = Vec::new();
+    let mut current_episode: Option<usize> = None;
+    let mut event_counter = 0usize;
+
+    for item in items {
+        match item {
+            FixtureItem::EpisodeStart { label } => {
+                episodes.push(EpisodeInfo {
+                    label,
+                    event_ids: Vec::new(),
+                });
+                current_episode = Some(episodes.len() - 1);
+            }
+            FixtureItem::Event { id, kind, payload } => {
+                if current_episode.is_none() {
+                    let label = format!("E{}", episodes.len() + 1);
+                    episodes.push(EpisodeInfo {
+                        label,
+                        event_ids: Vec::new(),
+                    });
+                    current_episode = Some(episodes.len() - 1);
+                }
+
+                event_counter += 1;
+                let event_id = id.unwrap_or_else(|| format!("fixture_evt_{}", event_counter));
+                let external = event_from_payload(&event_id, kind, payload)?;
+                session.on_event(external);
+
+                let episode_index = current_episode.expect("episode index set");
+                episodes[episode_index].event_ids.push(event_id);
+            }
+        }
+    }
+
+    if episodes.is_empty() {
+        return Err("fixture contained no episodes".to_string());
+    }
+
+    if episodes.iter().all(|episode| episode.event_ids.is_empty()) {
+        return Err("fixture contained no events".to_string());
+    }
+
+    if let Some(episode) = episodes.iter().find(|episode| episode.event_ids.is_empty()) {
+        return Err(format!("episode '{}' has no events", episode.label));
+    }
+
+    let bundle = session.into_bundle();
+    let summaries = summarize_episodes(&episodes, &bundle)?;
+
+    let artifact_path =
+        output_path.unwrap_or_else(|| PathBuf::from("target").join(DEFAULT_ARTIFACT_NAME));
+    write_replay_artifact(&artifact_path, &bundle)?;
+
+    Ok(FixtureRunResult {
+        artifact_path,
+        episodes: summaries,
+    })
+}
+
+fn event_from_payload(
+    event_id: &str,
+    kind: ExternalEventKind,
+    payload: Option<serde_json::Value>,
+) -> Result<ExternalEvent, String> {
+    let event_id_value = EventId::new(event_id);
+    if let Some(payload) = payload {
+        let data = serde_json::to_vec(&payload)
+            .map_err(|err| format!("fixture payload encode error for event '{event_id}': {err}"))?;
+        Ok(ExternalEvent::with_payload(
+            event_id_value,
+            kind,
+            EventTime::default(),
+            EventPayload { data },
+        ))
+    } else {
+        Ok(ExternalEvent::mechanical(event_id_value, kind))
+    }
+}
+
+fn summarize_episodes(
+    episodes: &[EpisodeInfo],
+    bundle: &CaptureBundle,
+) -> Result<Vec<EpisodeSummary>, String> {
+    let mut decisions_by_event: HashMap<String, Vec<Decision>> = HashMap::new();
+    for record in &bundle.decisions {
+        decisions_by_event
+            .entry(record.event_id.as_str().to_string())
+            .or_default()
+            .push(record.decision);
+    }
+
+    let mut context_by_event: HashMap<String, Option<f64>> = HashMap::new();
+    for record in &bundle.events {
+        context_by_event.insert(
+            record.event_id.as_str().to_string(),
+            context_value_from_payload(&record.payload),
+        );
+    }
+
+    let mut summaries = Vec::new();
+
+    for episode in episodes {
+        let mut invoked = false;
+        let mut deferred = false;
+        let mut invoked_event: Option<&String> = None;
+
+        for event_id in &episode.event_ids {
+            let entries = decisions_by_event
+                .get(event_id)
+                .ok_or_else(|| format!("no decision for event '{event_id}'"))?;
+            if entries.iter().any(|decision| *decision == Decision::Invoke) {
+                invoked = true;
+                if invoked_event.is_none() {
+                    invoked_event = Some(event_id);
+                }
+            }
+            if entries.iter().any(|decision| *decision == Decision::Defer) {
+                deferred = true;
+            }
+        }
+
+        let decision = if invoked {
+            "invoke"
+        } else if deferred {
+            "defer"
+        } else {
+            "none"
+        };
+
+        let (trigger_a, trigger_b, action_a, action_b) = if invoked {
+            let context_value = invoked_event
+                .and_then(|event_id| context_by_event.get(event_id))
+                .copied()
+                .flatten();
+            let summary = demo_1::summary_for_context_value(context_value);
+            (
+                trigger_status(summary.action_a_outcome.clone()),
+                trigger_status(summary.action_b_outcome.clone()),
+                action_status(summary.action_a_outcome),
+                action_status(summary.action_b_outcome),
+            )
+        } else {
+            ("deferred", "deferred", "deferred", "deferred")
+        };
+
+        summaries.push(EpisodeSummary {
+            label: episode.label.clone(),
+            decision: decision.to_string(),
+            trigger_a: trigger_a.to_string(),
+            trigger_b: trigger_b.to_string(),
+            action_a: action_a.to_string(),
+            action_b: action_b.to_string(),
+        });
+    }
+
+    Ok(summaries)
+}
+
+fn action_status(outcome: ActionOutcome) -> &'static str {
+    if outcome == ActionOutcome::Skipped {
+        "skipped"
+    } else {
+        "executed"
+    }
+}
+
+fn trigger_status(outcome: ActionOutcome) -> &'static str {
+    if outcome == ActionOutcome::Skipped {
+        "not_emitted"
+    } else {
+        "emitted"
+    }
+}
+
+fn context_value_from_payload(payload: &EventPayload) -> Option<f64> {
+    if payload.data.is_empty() {
+        return None;
+    }
+
+    let parsed: serde_json::Value = serde_json::from_slice(&payload.data).ok()?;
+    parsed
+        .as_object()
+        .and_then(|object| object.get(demo_1::CONTEXT_NUMBER_KEY))
+        .and_then(|value| value.as_f64())
+}
+
+fn write_replay_artifact(path: &PathBuf, bundle: &CaptureBundle) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| format!("create replay directory: {err}"))?;
+    }
+
+    let data = serde_json::to_string_pretty(bundle)
+        .map_err(|err| format!("serialize replay bundle: {err}"))?;
+    fs::write(path, format!("{data}\n")).map_err(|err| format!("write replay artifact: {err}"))?;
+    Ok(())
+}

--- a/crates/supervisor/src/lib.rs
+++ b/crates/supervisor/src/lib.rs
@@ -14,6 +14,8 @@ use serde::{Deserialize, Serialize};
 pub(crate) const CAPTURE_FORMAT_VERSION: &str = "v0";
 
 mod capture;
+#[cfg(any(test, feature = "demo"))]
+pub mod fixture_runner;
 pub mod replay;
 
 #[cfg(any(test, feature = "demo"))]


### PR DESCRIPTION
## Summary

Splits fixture-running logic into parser (adapter) and runner (supervisor). Eliminates 4 public traits from original implementation.

### Architecture

```
CLI
 ├── ergo_adapter::fixture::parse_fixture() → Vec<FixtureItem>
 └── ergo_supervisor::fixture_runner::run_fixture() → FixtureRunResult
```

### What Changed
- `crates/adapter/src/fixture.rs` (NEW): JSONL parsing, no supervisor dependencies
- `crates/supervisor/src/fixture_runner.rs` (NEW): Drives CapturingSession directly
- `crates/adapter/src/file_adapter.rs` (DELETED): Removed trait-based approach
- `crates/ergo-cli/src/main.rs`: Thin wrapper delegating to parser + runner

### Traits Removed
- OutcomeResolver
- DecisionRecordView
- CaptureBundleView
- FixtureSession

**Public traits added: 0**

---

## Invariant Mapping

### ✅ Invariants now enforced
None — structural refactor only

### ⚠️ Invariants potentially weakened
None

### Exercised
- **CXT-1** — Context flow unchanged
- **REP-1** — Capture/replay path unchanged
- **SUP-1, SUP-2** — Supervisor semantics unchanged

### Notes
- Refactor only: responsibilities moved, no behavior changes
- Parser has zero supervisor dependencies (verified)
- Runner uses CapturingSession directly (no trait indirection)
- CLI reduced from ~180 lines to ~30 lines for fixture handling
- Output format unchanged, replay identity ✅

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)