### PR TITLE
docs: sync stdlib documentation after context_number_source

### DIFF
--- a/crates/runtime/README.md
+++ b/crates/runtime/README.md
@@ -61,12 +61,12 @@ Context keys are strings. Current implementations:
 
 All default behaviors are deterministic. Missing or malformed payload data produces consistent outputs across replay.
 
-## Core stdlib wiring
+## Core stdlib wiring (29 implementations)
 
-- Sources: `number_source`, `boolean_source`, `string_source`, `context_number_source`
-- Computes: `const_number`, `const_bool`, `add`, `subtract`, `multiply`, `divide`, `negate`, `gt`, `lt`, `eq`, `neq`, `and`, `or`, `not`, `select`
-- Trigger: `emit_if_true`
-- Actions: `ack_action`, `annotate_action`
+- **Sources (4):** `number_source`, `boolean_source`, `string_source`, `context_number_source`
+- **Computes (22):** `const_number`, `const_bool`, `add`, `subtract`, `multiply`, `divide`, `abs`, `negate`, `gt`, `gte`, `lt`, `lte`, `eq`, `neq`, `min`, `max`, `and`, `or`, `not`, `select`, `select_bool`
+- **Trigger (1):** `emit_if_true`
+- **Actions (2):** `ack_action`, `annotate_action`
 
 Helpers:
 - `catalog::build_core_catalog()` builds a `PrimitiveCatalog` for validation/inference

--- a/docs/TOPICS/stdlib.md
+++ b/docs/TOPICS/stdlib.md
@@ -8,25 +8,47 @@
 
 The v0 kernel includes domain-neutral standard library atoms.
 
-### Sources
+Total stdlib implementations: 29
+
+### Sources (4)
 
 - `number_source` — Produces a configured number value
+- `boolean_source` — Produces a configured boolean value
 - `string_source` — Produces a configured string value (STRING-SOURCE-1)
+- `context_number_source` — Reads number from ExecutionContext (CONTEXT-NUMBER-SOURCE-1)
 
-### Computes
+### Computes (22)
 
-- `add`, `multiply`, `subtract`, `divide` — Arithmetic
-- `gt`, `gte`, `lt`, `lte` — Comparison
-- `abs`, `min`, `max` — Unary/binary operations
-- `select_bool` — Conditional selection
+- `const_number` — Outputs a constant number
+- `const_bool` — Outputs a constant boolean
+- `add` — Adds two numbers
+- `subtract` — Subtracts two numbers
+- `multiply` — Multiplies two numbers
+- `divide` — Divides two numbers
+- `abs` — Absolute value
+- `negate` — Negates a number
+- `gt` — Greater than comparison
+- `gte` — Greater than or equal comparison
+- `lt` — Less than comparison
+- `lte` — Less than or equal comparison
+- `eq` — Equality comparison
+- `neq` — Inequality comparison
+- `min` — Minimum of two numbers
+- `max` — Maximum of two numbers
+- `and` — Logical AND
+- `or` — Logical OR
+- `not` — Logical NOT
+- `select` — Select between two numbers based on condition
+- `select_bool` — Select between two booleans based on condition
 
-### Triggers
+### Triggers (1)
 
-- `emit_if_true` — Emits event when input is true
+- `emit_if_true` — Emits when input is true
 
-### Actions
+### Actions (2)
 
-- `ack_action` — Acknowledges trigger (test primitive)
+- `ack_action` — Acknowledges execution
+- `annotate_action` — Adds annotation to execution context
 
 **Catalog:** `crates/runtime/src/catalog.rs`
 
@@ -63,8 +85,8 @@ Every `ValueType` must have at least one source producer (X.12).
 
 | ValueType | Source |
 |-----------|--------|
-| Number | number_source |
-| Bool | number_source + compute |
+| Number | number_source, context_number_source |
+| Bool | boolean_source |
 | String | string_source |
 | Series | (derived from compute) |
 | Event | (derived from trigger) |

--- a/docs/closure_register.md
+++ b/docs/closure_register.md
@@ -313,6 +313,41 @@ Reframe as **Reference Client**:
 
 ---
 
+## CONTEXT-NUMBER-SOURCE-1 — Payload-derived context value
+
+**Date:** 2026-01-10
+**Status:** CLOSED
+**Category:** Source Coverage Completion
+
+### Finding
+
+Source primitives lacked ability to read values from event payloads.
+source.md §3 specifies "All dependencies must be parameters or orchestrator context"
+but no context-reading source existed.
+
+### Resolution
+
+Added `context_number_source`:
+- Reads key "x" from ExecutionContext via `ctx.value(key).and_then(|v| v.as_number())`
+- Returns 0.0 on missing key or type mismatch (deterministic default)
+- `SourcePrimitive::produce()` signature extended to receive `&ExecutionContext`
+
+### Justification
+- source.md §3: "All dependencies must be parameters or orchestrator context"
+- source.md §6: Lists `context_string` as canonical v0 example
+- SUPERVISOR.md §2.2: ExecutionContext contains "event payloads"
+- DEMO-2: Vertical proof showing trigger flip based on payload x=0.0 vs x=5.0
+
+### Tests
+- `context_number_source_reads_context_value`
+- `context_number_source_missing_key_returns_default`
+- `context_number_source_wrong_type_returns_default`
+
+### PR/Commit
+PR #31, #32
+
+---
+
 ## Semantics Decision Queue (v1)
 
 ### B.2 — Divide-by-zero behavior


### PR DESCRIPTION
## Summary

Syncs documentation after PRs #28-33, primarily documenting context_number_source addition.

### Changes
- **closure_register.md**: Add CONTEXT-NUMBER-SOURCE-1 entry with justification
- **docs/TOPICS/stdlib.md**: Complete inventory (was missing boolean_source, context_number_source, and 9 computes)
- **crates/runtime/README.md**: Complete compute list (was claiming 15, actual is 22)

### Stdlib Inventory (29 total)

| Category | Count | Implementations |
|----------|-------|-----------------|
| Sources | 4 | number_source, boolean_source, string_source, context_number_source |
| Computes | 22 | const_number, const_bool, add, subtract, multiply, divide, abs, negate, gt, gte, lt, lte, eq, neq, min, max, and, or, not, select, select_bool |
| Triggers | 1 | emit_if_true |
| Actions | 2 | ack_action, annotate_action |

### Invariant Mapping

#### Invariants now enforced
None — documentation sync only

#### Notes
- No code changes
- context_number_source addition justified per source.md §3, §6 and SUPERVISOR.md §2.2
- DEMO-2 served as vertical proof

---

Generated with [Claude Code](https://claude.com/claude-code)