### PR TITLE
docs: compute.md error semantics + version tag alignment

### DIFF
--- a/crates/runtime/README.md
+++ b/crates/runtime/README.md
@@ -61,10 +61,10 @@ Context keys are strings. Current implementations:
 
 All default behaviors are deterministic. Missing or malformed payload data produces consistent outputs across replay.
 
-## Core stdlib wiring (29 implementations)
+## Core stdlib wiring (30 implementations)
 
 - **Sources (4):** `number_source`, `boolean_source`, `string_source`, `context_number_source`
-- **Computes (22):** `const_number`, `const_bool`, `add`, `subtract`, `multiply`, `divide`, `abs`, `negate`, `gt`, `gte`, `lt`, `lte`, `eq`, `neq`, `min`, `max`, `and`, `or`, `not`, `select`, `select_bool`
+- **Computes (23):** `const_number`, `const_bool`, `add`, `subtract`, `multiply`, `divide`, `safe_divide`, `abs`, `negate`, `gt`, `gte`, `lt`, `lte`, `eq`, `neq`, `min`, `max`, `and`, `or`, `not`, `select`, `select_bool`
 - **Trigger (1):** `emit_if_true`
 - **Actions (2):** `ack_action`, `annotate_action`
 

--- a/docs/CANONICAL/KERNEL_CLOSURE.md
+++ b/docs/CANONICAL/KERNEL_CLOSURE.md
@@ -1,10 +1,10 @@
 ---
 Authority: CANONICAL
-Version: v0
-Last Updated: 2026-01-06
+Version: v1
+Last Updated: 2026-01-11
 Owner: Claude (Structural Auditor)
 Scope: v0 baseline declaration, v1 workstream rules
-Verified Against Tag: v0.28-kernel-closed
+Verified Against Tag: v1.0.0-alpha.1
 Change Rule: Operational log
 ---
 
@@ -83,6 +83,16 @@ Every kernel-changing merge must correspond to:
 - A tag that anchors the reference point when appropriate
 
 If a change would confuse a new contributor reading the docs, it needs a doctrine update or a separate PR.
+
+---
+
+## v1 Workstream Log
+
+Tracks semantic changes that exceed v0 scope.
+
+| Item | PR  | Tag            | Description                                                                                                                  |
+|------|-----|----------------|------------------------------------------------------------------------------------------------------------------------------|
+| B.2  | #35 | v1.0.0-alpha.1 | Divide-by-zero semantics: strict divide errors, safe_divide with fallback, NUM-FINITE-1 guard, SemanticError classification |
 
 ---
 

--- a/docs/CANONICAL/PHASE_INVARIANTS.md
+++ b/docs/CANONICAL/PHASE_INVARIANTS.md
@@ -4,7 +4,7 @@ Version: v0.21
 Owner: Claude (Structural Auditor)
 Last Updated: 2026-01-05
 Scope: Phase boundaries, enforcement loci, gap tracking
-Verified Against Tag: v0.28-kernel-closed
+Verified Against Tag: v1.0.0-alpha.1
 Change Rule: Operational log
 ---
 

--- a/docs/CANONICAL/TERMINOLOGY.md
+++ b/docs/CANONICAL/TERMINOLOGY.md
@@ -4,7 +4,7 @@ Version: v0
 Last Updated: 2025-12-22
 Owner: Claude (Structural Auditor)
 Scope: Canonical terms - primitive, implementation, cluster
-Verified Against Tag: v0.28-kernel-closed
+Verified Against Tag: v1.0.0-alpha.1
 Change Rule: Operational log
 ---
 

--- a/docs/CONTRACTS/INDEX.md
+++ b/docs/CONTRACTS/INDEX.md
@@ -3,7 +3,7 @@ Authority: CONTRACTS
 Version: v0
 Last Updated: 2026-01-06
 Scope: Index of all external interface contracts
-Verified Against Tag: v0.28-kernel-closed
+Verified Against Tag: v1.0.0-alpha.1
 Change Rule: Review required
 ---
 

--- a/docs/CONTRACTS/UI_RUNTIME_CONTRACT.md
+++ b/docs/CONTRACTS/UI_RUNTIME_CONTRACT.md
@@ -4,7 +4,7 @@ Version: v0
 Last Updated: 2026-01-05
 Derived From: src/runtime/tests.rs::hello_world_graph_executes_with_core_catalog_and_registries
 Scope: Data structures UI must emit for runtime
-Verified Against Tag: v0.28-kernel-closed
+Verified Against Tag: v1.0.0-alpha.1
 Change Rule: Review required
 ---
 

--- a/docs/FROZEN/SUPERVISOR.md
+++ b/docs/FROZEN/SUPERVISOR.md
@@ -3,7 +3,7 @@ Authority: FROZEN
 Version: v0
 Last Amended: 2025-12-27
 Scope: Orchestration layer, episode semantics, replay
-Verified Against Tag: v0.28-kernel-closed
+Verified Against Tag: v1.0.0-alpha.1
 Change Rule: v1 only
 ---
 

--- a/docs/FROZEN/V0_FREEZE.md
+++ b/docs/FROZEN/V0_FREEZE.md
@@ -3,7 +3,7 @@ Authority: FROZEN
 Version: v0
 Last Amended: 2025-12-28
 Scope: What is frozen vs patchable, version boundaries
-Verified Against Tag: v0.28-kernel-closed
+Verified Against Tag: v1.0.0-alpha.1
 Change Rule: v1 only
 ---
 

--- a/docs/FROZEN/adapter_contract.md
+++ b/docs/FROZEN/adapter_contract.md
@@ -3,7 +3,7 @@ Authority: FROZEN
 Version: v0
 Last Updated: 2025-12-22
 Scope: Trust boundary, replay guarantees, capture requirements
-Verified Against Tag: v0.28-kernel-closed
+Verified Against Tag: v1.0.0-alpha.1
 Change Rule: v1 only
 ---
 

--- a/docs/FROZEN/execution_model.md
+++ b/docs/FROZEN/execution_model.md
@@ -3,7 +3,7 @@ Authority: FROZEN
 Version: v0
 Last Amended: 2025-12-28
 Scope: Evaluation semantics, phase rules, determinism
-Verified Against Tag: v0.28-kernel-closed
+Verified Against Tag: v1.0.0-alpha.1
 Change Rule: v1 only
 ---
 

--- a/docs/FROZEN/ontology.md
+++ b/docs/FROZEN/ontology.md
@@ -3,7 +3,7 @@ Authority: FROZEN
 Version: v0
 Last Amended: 2025-12-28
 Scope: Four primitives, wiring matrix, causal roles
-Verified Against Tag: v0.28-kernel-closed
+Verified Against Tag: v1.0.0-alpha.1
 Change Rule: v1 only
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -94,7 +94,7 @@ If you find duplicate content, the FROZEN/STABLE/CANONICAL/CONTRACTS version is 
 
 ### Verified Against
 
-All documents verified against tag: `v0.28-kernel-closed`
+All documents verified against tag: `v1.0.0-alpha.1`
 
 ---
 

--- a/docs/STABLE/AUTHORING_LAYER.md
+++ b/docs/STABLE/AUTHORING_LAYER.md
@@ -3,7 +3,7 @@ Authority: STABLE
 Version: v0
 Last Updated: 2025-12-22
 Scope: Cluster concepts, fractal composition, boundary kinds
-Verified Against Tag: v0.28-kernel-closed
+Verified Against Tag: v1.0.0-alpha.1
 Change Rule: Additive only
 ---
 

--- a/docs/STABLE/CLUSTER_SPEC.md
+++ b/docs/STABLE/CLUSTER_SPEC.md
@@ -3,7 +3,7 @@ Authority: STABLE
 Version: v0.2
 Last Updated: 2025-12-22
 Scope: Data structures, inference algorithm, validation rules
-Verified Against Tag: v0.28-kernel-closed
+Verified Against Tag: v1.0.0-alpha.1
 Change Rule: Additive only
 ---
 

--- a/docs/STABLE/PRIMITIVE_MANIFESTS/compute.md
+++ b/docs/STABLE/PRIMITIVE_MANIFESTS/compute.md
@@ -1,7 +1,7 @@
 ---
 Authority: STABLE
 Version: v0
-Last Updated: 2025-12-22
+Last Updated: 2026-01-11
 ---
 
 # Compute Primitive Manifest — v0
@@ -100,12 +100,15 @@ Rules:
 execution:
   cadence: continuous | event
   deterministic: true
+  may_error: true
 ```
 
 Rules:
+
 - `continuous` = evaluated every bar / tick
 - `event` = evaluated only on upstream event emission
 - Determinism is required
+- Errors are permitted for domain-specific edge cases (see §2.8)
 
 ---
 
@@ -134,15 +137,44 @@ side_effects: false
 ```
 
 Hard rule:
+
 - Compute primitives may not perform I/O
 - May not access network, filesystem, or external state
 - If it touches the world, it is not compute
 
 ---
 
+### 2.8 Error Semantics
+
+```yaml
+errors:
+  allowed: true
+  deterministic: true
+```
+
+Rules:
+
+- Compute primitives may produce errors for domain-specific edge cases
+- Errors must be deterministic (same inputs → same error)
+- When execution succeeds, all declared outputs must be produced
+- When execution fails, no outputs are produced
+- Errors surface as `ExecError::ComputeFailed` at runtime
+
+Error types (B.2):
+
+- `DivisionByZero` — Division by zero attempted
+- `NonFiniteResult` — Result overflowed to infinity or NaN
+
+Errors are semantic failures, not infrastructure failures. They are non-retryable.
+
+See: PHASE_INVARIANTS.md B.2, NUM-FINITE-1
+
+---
+
 ## 3. Prohibited Behavior
 
 A compute primitive may not:
+
 - Read or write files
 - Access network resources
 - Inspect execution mode
@@ -152,6 +184,7 @@ A compute primitive may not:
 - Branch on execution mode
 - Accept undeclared inputs or parameters
 - Emit undeclared outputs
+- Emit non-deterministic errors
 
 Violation invalidates the primitive.
 


### PR DESCRIPTION
## Summary

Post-B.2 documentation alignment.

### compute.md
- §2.5: add `may_error: true` to execution semantics
- §2.8: new Error Semantics section (B.2 reference)
- §3: add "non-deterministic errors" to prohibited behavior

### crates/runtime/README.md
- 30 implementations (was 29)
- 23 computes (was 22)
- Added `safe_divide` to list

### KERNEL_CLOSURE.md
- Version: v0 → v1
- Added v1 Workstream Log with B.2 entry

### All docs
- `Verified Against Tag: v0.28-kernel-closed` → `v1.0.0-alpha.1`

## Test plan
- [x] `cargo fmt`
- [x] `cargo test --workspace` passes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)