### PR TITLE
docs: clarify NUM-FINITE-1 scope + B.2 notes

### DIFF
--- a/crates/runtime/src/compute/implementations/safe_divide/impl.rs
+++ b/crates/runtime/src/compute/implementations/safe_divide/impl.rs
@@ -37,6 +37,10 @@ impl ComputePrimitive for SafeDivide {
     /// This implementation never errors for zero/non-finite conditions.
     /// The author explicitly chooses the fallback value, encoding domain policy.
     ///
+    /// **Note:** `fallback` must be a finite number. If `fallback` is NaN or
+    /// infinity, safe_divide will return it, and the NUM-FINITE-1 runtime guard
+    /// will raise `ExecError::NonFiniteOutput`.
+    ///
     /// See: B.2 in PHASE_INVARIANTS.md
     fn compute(
         &self,

--- a/docs/CANONICAL/PHASE_INVARIANTS.md
+++ b/docs/CANONICAL/PHASE_INVARIANTS.md
@@ -131,6 +131,7 @@ These invariants hold across all phases. Violation at any point is a system-leve
 Non-finite numeric values (NaN, inf, -inf) are rejected at the execution boundary before they can propagate to downstream nodes.
 
 **Enforcement:**
+**Scope:** Guards Source and Compute outputs only. Action outputs are not guarded because actions are terminal (F.2) and cannot feed downstream nodes. If future actions emit numeric boundary outputs, this scope may need revisiting.
 - `ensure_finite()` defined at line 296
 - Number check at line 302
 - Series check at line 308

--- a/docs/closure_register.md
+++ b/docs/closure_register.md
@@ -395,6 +395,13 @@ Adopted Option C after stress-testing with ChatGPT:
 - Separating `divide` (strict) from `safe_divide` (explicit fallback) keeps primitives math-true
 - NUM-FINITE-1 provides defense-in-depth against non-finite values from any source
 
+### Implementation Notes
+
+- `ComputeError::DivisionByZero` and `ComputeError::NonFiniteResult` are specific to the `divide` implementation
+- Other computes producing inf/NaN (e.g., multiply overflow) are caught by the NUM-FINITE-1 runtime guard, which raises `ExecError::NonFiniteOutput`
+- `safe_divide` does not validate that `fallback` is finite — if a non-finite fallback is provided, NUM-FINITE-1 will catch it after the compute returns
+- Both error paths result in `ErrKind::SemanticError` (non-retryable)
+
 ### Tests
 - `divide_by_zero_errors`
 - `divide_by_negative_zero_errors`


### PR DESCRIPTION
## Summary

- Clarify NUM-FINITE-1 scope (Source/Compute outputs only) in PHASE_INVARIANTS
- Add safe_divide fallback finiteness warning in code docs
- Add B.2 implementation notes in closure_register

## Tests
- cargo fmt
- cargo test --workspace
