### PR TITLE
feat(runtime): add context_string_source

### DIFF
--- a/crates/kernel/runtime/README.md
+++ b/crates/kernel/runtime/README.md
@@ -63,15 +63,16 @@ Context keys are strings. Current context-reading implementations:
 
 - `context_number_source`: reads key from parameter `key` (default `"x"`)
 - `context_bool_source`: reads key from parameter `key` (default `"x"`)
+- `context_string_source`: reads key from parameter `key` (default `"x"`)
 - `context_series_source`: reads key from parameter `key` (default `"x"`)
 
 ### Determinism
 
 All default behaviors are deterministic. Missing or malformed payload data produces consistent outputs across replay.
 
-## Core stdlib wiring (41 implementations)
+## Core stdlib wiring (42 implementations)
 
-- **Sources (6):** `number_source`, `boolean_source`, `string_source`, `context_number_source`, `context_bool_source`, `context_series_source`
+- **Sources (7):** `number_source`, `boolean_source`, `string_source`, `context_number_source`, `context_bool_source`, `context_string_source`, `context_series_source`
 - **Computes (27):** `const_number`, `const_bool`, `add`, `subtract`, `multiply`, `divide`, `safe_divide`, `abs`, `negate`, `gt`, `gte`, `lt`, `lte`, `eq`, `neq`, `min`, `max`, `and`, `or`, `not`, `select`, `select_bool`, `append`, `window`, `mean`, `len`, `sum`
 - **Triggers (2):** `emit_if_true`, `emit_if_event_and_true`
 - **Actions (6):** `ack_action`, `annotate_action`, `context_set_number`, `context_set_bool`, `context_set_string`, `context_set_series`

--- a/crates/kernel/runtime/src/catalog.rs
+++ b/crates/kernel/runtime/src/catalog.rs
@@ -19,8 +19,9 @@ use crate::compute::{
     ComputePrimitive, ComputePrimitiveManifest, PrimitiveRegistry as ComputeRegistry,
 };
 use crate::source::{
-    BooleanSource, ContextBoolSource, ContextNumberSource, ContextSeriesSource, NumberSource,
-    SourcePrimitive, SourceRegistry, SourceValidationError, StringSource,
+    BooleanSource, ContextBoolSource, ContextNumberSource, ContextSeriesSource,
+    ContextStringSource, NumberSource, SourcePrimitive, SourceRegistry, SourceValidationError,
+    StringSource,
 };
 use crate::trigger::{
     EmitIfEventAndTrue, EmitIfTrue, TriggerPrimitive, TriggerRegistry, TriggerValidationError,
@@ -64,6 +65,7 @@ fn core_source_primitives() -> Vec<Box<dyn SourcePrimitive>> {
         Box::new(ContextNumberSource::new()),
         Box::new(ContextSeriesSource::new()),
         Box::new(ContextBoolSource::new()),
+        Box::new(ContextStringSource::new()),
         Box::new(BooleanSource::new()),
         Box::new(StringSource::new()),
     ]

--- a/crates/kernel/runtime/src/runtime/tests.rs
+++ b/crates/kernel/runtime/src/runtime/tests.rs
@@ -5256,6 +5256,105 @@ fn context_bool_source_runtime_uses_default_key_when_parameter_omitted() {
 }
 
 #[test]
+fn context_string_source_runtime_reads_custom_key_parameter() {
+    let expanded = ExpandedGraph {
+        nodes: HashMap::from([(
+            "src".to_string(),
+            ExpandedNode {
+                runtime_id: "src".to_string(),
+                authoring_path: vec![],
+                implementation: crate::cluster::ImplementationInstance {
+                    impl_id: "context_string_source".to_string(),
+                    requested_version: "0.1.0".to_string(),
+                    version: "0.1.0".to_string(),
+                },
+                parameters: HashMap::from([(
+                    "key".to_string(),
+                    crate::cluster::ParameterValue::String("sample_key".to_string()),
+                )]),
+            },
+        )]),
+        edges: vec![],
+        boundary_inputs: Vec::new(),
+        boundary_outputs: vec![crate::cluster::OutputPortSpec {
+            name: "out".to_string(),
+            maps_to: crate::cluster::OutputRef {
+                node_id: "src".to_string(),
+                port_name: "value".to_string(),
+            },
+        }],
+    };
+
+    let catalog = build_core_catalog();
+    let core = core_registries().unwrap();
+    let registries = Registries {
+        sources: &core.sources,
+        computes: &core.computes,
+        triggers: &core.triggers,
+        actions: &core.actions,
+    };
+
+    let ctx = ExecutionContext::from_values(HashMap::from([(
+        "sample_key".to_string(),
+        crate::common::Value::String("ready".to_string()),
+    )]));
+
+    let report = run(&expanded, &catalog, &registries, &ctx).unwrap();
+    assert_eq!(
+        report.outputs.get("out"),
+        Some(&RuntimeValue::String("ready".to_string()))
+    );
+}
+
+#[test]
+fn context_string_source_runtime_uses_default_key_when_parameter_omitted() {
+    let expanded = ExpandedGraph {
+        nodes: HashMap::from([(
+            "src".to_string(),
+            ExpandedNode {
+                runtime_id: "src".to_string(),
+                authoring_path: vec![],
+                implementation: crate::cluster::ImplementationInstance {
+                    impl_id: "context_string_source".to_string(),
+                    requested_version: "0.1.0".to_string(),
+                    version: "0.1.0".to_string(),
+                },
+                parameters: HashMap::new(),
+            },
+        )]),
+        edges: vec![],
+        boundary_inputs: Vec::new(),
+        boundary_outputs: vec![crate::cluster::OutputPortSpec {
+            name: "out".to_string(),
+            maps_to: crate::cluster::OutputRef {
+                node_id: "src".to_string(),
+                port_name: "value".to_string(),
+            },
+        }],
+    };
+
+    let catalog = build_core_catalog();
+    let core = core_registries().unwrap();
+    let registries = Registries {
+        sources: &core.sources,
+        computes: &core.computes,
+        triggers: &core.triggers,
+        actions: &core.actions,
+    };
+
+    let ctx = ExecutionContext::from_values(HashMap::from([(
+        "x".to_string(),
+        crate::common::Value::String("armed".to_string()),
+    )]));
+
+    let report = run(&expanded, &catalog, &registries, &ctx).unwrap();
+    assert_eq!(
+        report.outputs.get("out"),
+        Some(&RuntimeValue::String("armed".to_string()))
+    );
+}
+
+#[test]
 fn context_series_source_runtime_reads_custom_key_parameter() {
     let expanded = ExpandedGraph {
         nodes: HashMap::from([(

--- a/crates/kernel/runtime/src/source/implementations/context_string/impl.rs
+++ b/crates/kernel/runtime/src/source/implementations/context_string/impl.rs
@@ -1,0 +1,56 @@
+use std::collections::HashMap;
+
+use crate::common::Value;
+use crate::runtime::ExecutionContext;
+use crate::source::{ParameterValue, SourcePrimitive, SourcePrimitiveManifest};
+
+use super::manifest::context_string_source_manifest;
+
+const DEFAULT_CONTEXT_KEY: &str = "x";
+const KEY_PARAMETER: &str = "key";
+
+pub struct ContextStringSource {
+    manifest: SourcePrimitiveManifest,
+}
+
+impl ContextStringSource {
+    pub fn new() -> Self {
+        Self {
+            manifest: context_string_source_manifest(),
+        }
+    }
+}
+
+impl Default for ContextStringSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SourcePrimitive for ContextStringSource {
+    fn manifest(&self) -> &SourcePrimitiveManifest {
+        &self.manifest
+    }
+
+    fn produce(
+        &self,
+        parameters: &HashMap<String, ParameterValue>,
+        ctx: &ExecutionContext,
+    ) -> HashMap<String, Value> {
+        let context_key = parameters
+            .get(KEY_PARAMETER)
+            .and_then(|value| match value {
+                ParameterValue::String(string) => Some(string.as_str()),
+                _ => None,
+            })
+            .unwrap_or(DEFAULT_CONTEXT_KEY);
+
+        let value = ctx
+            .value(context_key)
+            .and_then(|value| value.as_string())
+            .map(str::to_string)
+            .unwrap_or_default();
+
+        HashMap::from([("value".to_string(), Value::String(value))])
+    }
+}

--- a/crates/kernel/runtime/src/source/implementations/context_string/manifest.rs
+++ b/crates/kernel/runtime/src/source/implementations/context_string/manifest.rs
@@ -1,0 +1,37 @@
+use crate::common::ValueType;
+use crate::source::{
+    Cadence, ContextRequirement, ExecutionSpec, OutputSpec, ParameterSpec, ParameterValue,
+    SourceKind, SourcePrimitiveManifest, SourceRequires, StateSpec,
+};
+
+pub fn context_string_source_manifest() -> SourcePrimitiveManifest {
+    SourcePrimitiveManifest {
+        id: "context_string_source".to_string(),
+        version: "0.1.0".to_string(),
+        kind: SourceKind::Source,
+        inputs: vec![],
+        outputs: vec![OutputSpec {
+            name: "value".to_string(),
+            value_type: ValueType::String,
+        }],
+        parameters: vec![ParameterSpec {
+            name: "key".to_string(),
+            value_type: ParameterValue::String(String::new()).value_type(),
+            default: Some(ParameterValue::String("x".to_string())),
+            bounds: None,
+        }],
+        requires: SourceRequires {
+            context: vec![ContextRequirement {
+                name: "$key".to_string(),
+                ty: ValueType::String,
+                required: false,
+            }],
+        },
+        execution: ExecutionSpec {
+            deterministic: true,
+            cadence: Cadence::Continuous,
+        },
+        state: StateSpec { allowed: false },
+        side_effects: false,
+    }
+}

--- a/crates/kernel/runtime/src/source/implementations/context_string/mod.rs
+++ b/crates/kernel/runtime/src/source/implementations/context_string/mod.rs
@@ -1,0 +1,5 @@
+mod r#impl;
+mod manifest;
+
+pub use manifest::context_string_source_manifest;
+pub use r#impl::ContextStringSource;

--- a/crates/kernel/runtime/src/source/implementations/mod.rs
+++ b/crates/kernel/runtime/src/source/implementations/mod.rs
@@ -2,6 +2,7 @@ pub mod boolean;
 pub mod context_bool;
 pub mod context_number;
 pub mod context_series;
+pub mod context_string;
 pub mod number;
 pub mod string;
 
@@ -9,5 +10,6 @@ pub use boolean::{boolean_source_manifest, BooleanSource};
 pub use context_bool::{context_bool_source_manifest, ContextBoolSource};
 pub use context_number::{context_number_source_manifest, ContextNumberSource};
 pub use context_series::{context_series_source_manifest, ContextSeriesSource};
+pub use context_string::{context_string_source_manifest, ContextStringSource};
 pub use number::{number_source_manifest, NumberSource};
 pub use string::{string_source_manifest, StringSource};

--- a/crates/kernel/runtime/src/source/mod.rs
+++ b/crates/kernel/runtime/src/source/mod.rs
@@ -332,8 +332,9 @@ pub trait SourcePrimitive {
 }
 
 pub use implementations::{
-    boolean, context_bool, context_number, context_series, number, string, BooleanSource,
-    ContextBoolSource, ContextNumberSource, ContextSeriesSource, NumberSource, StringSource,
+    boolean, context_bool, context_number, context_series, context_string, number, string,
+    BooleanSource, ContextBoolSource, ContextNumberSource, ContextSeriesSource,
+    ContextStringSource, NumberSource, StringSource,
 };
 pub use registry::SourceRegistry;
 

--- a/crates/kernel/runtime/src/source/tests.rs
+++ b/crates/kernel/runtime/src/source/tests.rs
@@ -7,12 +7,12 @@ use crate::runtime::ExecutionContext;
 use crate::source::{
     implementations::{
         context_bool_source_manifest, context_number_source_manifest,
-        context_series_source_manifest,
+        context_series_source_manifest, context_string_source_manifest,
     },
     BooleanSource, Cadence, ContextBoolSource, ContextNumberSource, ContextSeriesSource,
-    ExecutionSpec, InputSpec, NumberSource, OutputSpec, ParameterSpec, ParameterType, SourceKind,
-    SourcePrimitive, SourcePrimitiveManifest, SourceRegistry, SourceRequires,
-    SourceValidationError, StateSpec, StringSource,
+    ContextStringSource, ExecutionSpec, InputSpec, NumberSource, OutputSpec, ParameterSpec,
+    ParameterType, SourceKind, SourcePrimitive, SourcePrimitiveManifest, SourceRegistry,
+    SourceRequires, SourceValidationError, StateSpec, StringSource,
 };
 
 fn expect_panic<F: FnOnce() -> R + std::panic::UnwindSafe, R>(f: F) {
@@ -340,6 +340,122 @@ fn context_series_source_manifest_with_dollar_key_validates() {
     assert_eq!(manifest.requires.context.len(), 1);
     assert_eq!(manifest.requires.context[0].name, "$key");
     assert_eq!(manifest.requires.context[0].ty, ValueType::Series);
+    assert!(!manifest.requires.context[0].required);
+}
+
+#[test]
+fn context_string_source_reads_context_value_default_key() {
+    let source = ContextStringSource::new();
+    let ctx = ExecutionContext::from_values(HashMap::from([(
+        "x".to_string(),
+        Value::String("ready".to_string()),
+    )]));
+
+    let outputs = source.produce(&HashMap::new(), &ctx);
+    assert_eq!(
+        outputs.get("value"),
+        Some(&Value::String("ready".to_string()))
+    );
+}
+
+#[test]
+fn context_string_source_reads_context_value_custom_key() {
+    let source = ContextStringSource::new();
+    let ctx = ExecutionContext::from_values(HashMap::from([(
+        "sample_key".to_string(),
+        Value::String("armed".to_string()),
+    )]));
+
+    let outputs = source.produce(
+        &HashMap::from([(
+            "key".to_string(),
+            crate::source::ParameterValue::String("sample_key".to_string()),
+        )]),
+        &ctx,
+    );
+    assert_eq!(
+        outputs.get("value"),
+        Some(&Value::String("armed".to_string()))
+    );
+}
+
+#[test]
+fn context_string_source_missing_key_returns_default_empty_string() {
+    let source = ContextStringSource::new();
+    let ctx = ExecutionContext::from_values(HashMap::from([(
+        "other_key".to_string(),
+        Value::String("ignored".to_string()),
+    )]));
+
+    let outputs = source.produce(&HashMap::new(), &ctx);
+    assert_eq!(outputs.get("value"), Some(&Value::String(String::new())));
+}
+
+#[test]
+fn context_string_source_wrong_type_returns_default_empty_string() {
+    let source = ContextStringSource::new();
+    let ctx =
+        ExecutionContext::from_values(HashMap::from([("x".to_string(), Value::Number(42.0))]));
+
+    let outputs = source.produce(&HashMap::new(), &ctx);
+    assert_eq!(outputs.get("value"), Some(&Value::String(String::new())));
+}
+
+#[test]
+fn context_string_source_custom_key_missing_returns_default_empty_string() {
+    let source = ContextStringSource::new();
+    let ctx = ExecutionContext::from_values(HashMap::from([(
+        "other_key".to_string(),
+        Value::String("ignored".to_string()),
+    )]));
+
+    let outputs = source.produce(
+        &HashMap::from([(
+            "key".to_string(),
+            crate::source::ParameterValue::String("sample_key".to_string()),
+        )]),
+        &ctx,
+    );
+    assert_eq!(outputs.get("value"), Some(&Value::String(String::new())));
+}
+
+#[test]
+fn context_string_source_custom_key_wrong_type_returns_default_empty_string() {
+    let source = ContextStringSource::new();
+    let ctx = ExecutionContext::from_values(HashMap::from([(
+        "sample_key".to_string(),
+        Value::Bool(true),
+    )]));
+
+    let outputs = source.produce(
+        &HashMap::from([(
+            "key".to_string(),
+            crate::source::ParameterValue::String("sample_key".to_string()),
+        )]),
+        &ctx,
+    );
+    assert_eq!(outputs.get("value"), Some(&Value::String(String::new())));
+}
+
+#[test]
+fn context_string_source_manifest_with_dollar_key_validates() {
+    let manifest = context_string_source_manifest();
+    assert!(SourceRegistry::validate_manifest(&manifest).is_ok());
+
+    let key_param = manifest
+        .parameters
+        .iter()
+        .find(|p| p.name == "key")
+        .expect("context_string_source must declare 'key' parameter");
+    assert_eq!(key_param.value_type, ParameterType::String);
+    assert_eq!(
+        key_param.default,
+        Some(crate::source::ParameterValue::String("x".to_string()))
+    );
+
+    assert_eq!(manifest.requires.context.len(), 1);
+    assert_eq!(manifest.requires.context[0].name, "$key");
+    assert_eq!(manifest.requires.context[0].ty, ValueType::String);
     assert!(!manifest.requires.context[0].required);
 }
 

--- a/docs/contracts/extension-roadmap.md
+++ b/docs/contracts/extension-roadmap.md
@@ -375,7 +375,7 @@ capture:
 - `context.<key_name>` for each `context_keys[].name`
 - `effect.<effect_name>` for each `accepts.effects[].name`
 
-**Note:** Adapters do NOT need to pre-seed initial values for writable keys. Shipped context sources provide deterministic missing-key defaults on the same-ingestion path (`context_number_source`, `context_bool_source`, `context_series_source`). `context_string_source` remains deferred.
+**Note:** Adapters do NOT need to pre-seed initial values for writable keys. Shipped context sources provide deterministic missing-key defaults on the same-ingestion path (`context_number_source`, `context_bool_source`, `context_string_source`, `context_series_source`).
 
 **Deliverables:**
 
@@ -406,7 +406,7 @@ capture:
 | ADP-16 | Write effect must be capturable (planned; REP-SCOPE update required) | `any(writable == true) => "effect.set_context" ∈ capture.fields` |
 | ADP-17 | Writable keys cannot be required | `∀k where writable == true: k.required == false` |
 
-**Note on ADP-17:** Writable keys may not exist initially (no prior write). Setting `required: true` on a writable key would cause validation failures on first episode. Shipped context sources already handle missing keys via deterministic defaults on the same-ingestion path; `context_string_source` remains deferred.
+**Note on ADP-17:** Writable keys may not exist initially (no prior write). Setting `required: true` on a writable key would cause validation failures on first episode. Shipped context sources already handle missing keys via deterministic defaults on the same-ingestion path.
 
 **Note on ADP-15/ADP-16:** Planned manifest extension. Same-ingestion Scope A replay already verifies host-owned effect integrity, including `set_context` writes. The deferred work is making that coverage declarative in adapter `capture.fields` and defining any broader cross-ingestion parity requirements.
 
@@ -1480,7 +1480,7 @@ fn adp_5_duplicate_context_key_rejected() {
 
 ## Phase 8: Stdlib State Implementations
 
-**Status:** Substantially complete. All core context source and action implementations are shipped except `context_string_source`.
+**Status:** Complete for the typed context source/action family.
 
 ### Core Freeze Clarification
 
@@ -1496,8 +1496,8 @@ These are a family of implementations, one per supported type:
 
 - `context_number_source@0.1.0` (parameterized key, default `"x"`) — **shipped**
 - `context_bool_source@0.1.0` — **shipped**
+- `context_string_source@0.1.0` — **shipped**
 - `context_series_source@0.1.0` — **shipped**
-- `context_string_source` — deferred
 
 A context source reads a value from the execution context — a key-value map provided by the adapter at each event. The source does not know or care whether the adapter populated that key from external data (market feed, user command) or from a prior episode's `context_set_*` write. Both paths are identical from the source's perspective.
 
@@ -1624,7 +1624,7 @@ effects:
 
 - [x] `context_number_source@0.1.0` parameterized with `key` default `"x"` in `crates/kernel/runtime/src/source/implementations/context_number/`
 - [x] `context_bool_source@0.1.0` in `crates/kernel/runtime/src/source/implementations/context_bool/`
-- [ ] `context_string_source@0.1.0` (deferred)
+- [x] `context_string_source@0.1.0` in `crates/kernel/runtime/src/source/implementations/context_string/`
 - [x] `context_set_number@0.1.0`, `context_set_bool@0.1.0`, `context_set_string@0.1.0` in `crates/kernel/runtime/src/action/implementations/`
 - [x] `$key` parameter resolution in manifest/composition validation
 - [x] Effect routing/capture/replay integrity tests with real stdlib implementations

--- a/docs/ledger/dev-work/closed/context-string-source.md
+++ b/docs/ledger/dev-work/closed/context-string-source.md
@@ -2,7 +2,7 @@
 Authority: PROJECT
 Date: 2026-03-19
 Author: Codex (Implementation)
-Status: OPEN
+Status: CLOSED
 Branch: feat/context-string-source
 Tier: 1 (Stdlib Completeness)
 Depends-On: >-
@@ -52,12 +52,12 @@ Today:
 
 | ID | Task | Closure Condition | Owner | Status |
 |----|------|-------------------|-------|--------|
-| CSS-1 | Add manifest + implementation | `context_string_source@0.1.0` exists under `crates/kernel/runtime/src/source/implementations/context_string/` and follows the existing context-source pattern. | Codex | OPEN |
-| CSS-2 | Register in core stdlib | The source is admitted through the shared catalog/registry build path and available in runtime tests and downstream surfaces. | Codex | OPEN |
-| CSS-3 | Implement deterministic defaults | Missing key and wrong-type reads deterministically return empty string, matching the existing typed context-source family design. | Codex | OPEN |
-| CSS-4 | Validate `$key` contract | Manifest uses the same parameter-bound `$key` requirement pattern and passes existing source registration/composition rules. | Codex | OPEN |
-| CSS-5 | Add tests | Source tests and runtime tests prove default-key read, custom-key read, missing-key fallback, wrong-type fallback, and manifest validation. | Codex | OPEN |
-| CSS-6 | Align docs | Runtime README and any remaining roadmap/reference docs reflect `context_string_source` as shipped once code lands. | Codex | OPEN |
+| CSS-1 | Add manifest + implementation | `context_string_source@0.1.0` exists under `crates/kernel/runtime/src/source/implementations/context_string/` and follows the existing context-source pattern. | Codex | CLOSED |
+| CSS-2 | Register in core stdlib | The source is admitted through the shared catalog/registry build path and available in runtime tests and downstream surfaces. | Codex | CLOSED |
+| CSS-3 | Implement deterministic defaults | Missing key and wrong-type reads deterministically return empty string, matching the existing typed context-source family design. | Codex | CLOSED |
+| CSS-4 | Validate `$key` contract | Manifest uses the same parameter-bound `$key` requirement pattern and passes existing source registration/composition rules. | Codex | CLOSED |
+| CSS-5 | Add tests | Source tests and runtime tests prove default-key read, custom-key read, missing-key fallback, wrong-type fallback, and manifest validation. | Codex | CLOSED |
+| CSS-6 | Align docs | Runtime README and any remaining roadmap/reference docs reflect `context_string_source` as shipped once code lands. | Codex | CLOSED |
 
 ## Design Constraints
 

--- a/docs/ledger/dev-work/closed/runtime-version-alignment.md
+++ b/docs/ledger/dev-work/closed/runtime-version-alignment.md
@@ -2,8 +2,9 @@
 Authority: PROJECT
 Date: 2026-03-19
 Author: Codex (Implementation)
-Status: OPEN
+Status: CLOSED
 Branch: fix/runtime-version-alignment
+Landing-Commit: 1ecf81c
 Tier: 1 (Correctness Cleanup)
 Depends-On: none
 ---
@@ -39,10 +40,10 @@ Today:
 
 | ID | Task | Closure Condition | Owner | Status |
 |----|------|-------------------|-------|--------|
-| RVA-1 | Export runtime version truthfully | `ergo-runtime` exposes a canonical runtime version constant or equivalent source that reflects the runtime crate version used by the build. | Codex | OPEN |
-| RVA-2 | Remove adapter placeholder | Adapter ADP-3 validation uses the runtime-owned version source instead of a local hardcoded string. | Codex | OPEN |
-| RVA-3 | Update tests | Adapter validation tests no longer rely on the placeholder comment/assumption and continue to prove incompatible runtime rejection truthfully. | Codex | OPEN |
-| RVA-4 | Preserve behavior | Existing ADP-3 comparison behavior remains semver-based and all relevant tests pass after the source-of-truth swap. | Codex | OPEN |
+| RVA-1 | Export runtime version truthfully | `ergo-runtime` exposes a canonical runtime version constant or equivalent source that reflects the runtime crate version used by the build. | Codex | CLOSED |
+| RVA-2 | Remove adapter placeholder | Adapter ADP-3 validation uses the runtime-owned version source instead of a local hardcoded string. | Codex | CLOSED |
+| RVA-3 | Update tests | Adapter validation tests no longer rely on the placeholder comment/assumption and continue to prove incompatible runtime rejection truthfully. | Codex | CLOSED |
+| RVA-4 | Preserve behavior | Existing ADP-3 comparison behavior remains semver-based and all relevant tests pass after the source-of-truth swap. | Codex | CLOSED |
 
 ## Design Constraints
 

--- a/docs/primitives/source.md
+++ b/docs/primitives/source.md
@@ -365,6 +365,42 @@ This source reads the context key named by parameter `key` (default `"x"`). Sinc
 `required: false`, missing keys and wrong-type values resolve to the source default
 (`false`).
 
+### Source with string context requirements
+
+```yaml
+kind: source
+id: context_string_source
+version: 0.1.0
+
+outputs:
+  - name: value
+    type: String
+
+parameters:
+  - name: key
+    type: string
+    default: "x"
+
+requires:
+  context:
+    - name: $key
+      type: String
+      required: false
+
+execution:
+  cadence: continuous
+  deterministic: true
+
+state:
+  allowed: false
+
+side_effects: false
+```
+
+This source reads the context key named by parameter `key` (default `"x"`). Since
+`required: false`, missing keys and wrong-type values resolve to the source default
+(`""`).
+
 ### Source without context requirements
 
 ```yaml


### PR DESCRIPTION
## Summary

- Add context_string_source manifest and implementation
- Register it in the core runtime catalog and source exports
- Add source and runtime coverage for default/custom key reads
- Document the shipped string context source and close the dev-work items

## Test plan
- [x] Source tests for default and custom key reads
- [x] Runtime integration tests
- [x] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)