### PR TITLE
Repair runtime surface verification workflow

### DIFF
--- a/.github/workflows/runtime-surface.yml
+++ b/.github/workflows/runtime-surface.yml
@@ -11,15 +11,47 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  verify-runtime-surface:
-    name: Verify (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
+  doctrine-and-boundaries:
+    name: Doctrine + boundaries
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify replay naming
+        shell: bash
+        run: bash tools/verify_replay_naming.sh
+
+      - name: Verify doctrine gate
+        shell: bash
+        run: bash tools/verify_doctrine_gate.sh
+
+      - name: Verify layer boundaries
+        shell: bash
+        run: bash tools/verify_layer_boundaries.sh
+
+      - name: Verify invariant index
+        shell: bash
+        run: bash tools/verify_invariant_index.sh
+
+      - name: Verify ergo-mcp parser tests
+        shell: bash
+        run: |
+          if [[ -d "tools/ergo-mcp" ]]; then
+            python -m unittest discover -s tools/ergo-mcp -p "test_*.py"
+          else
+            echo "skipping ergo-mcp invariant parser tests (tools/ergo-mcp not present)"
+          fi
+
+  rust-verify:
+    name: Rust verify (ubuntu-latest)
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -38,6 +70,25 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Verify runtime surface
-        shell: bash
-        run: bash verify_runtime_surface.sh
+      - name: Cargo fmt
+        run: cargo fmt --check
+
+      - name: Cargo test workspace
+        run: cargo test --workspace
+
+  windows-compile:
+    name: Windows compile (windows-latest)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Cargo check workspace
+        run: cargo check --workspace

--- a/crates/kernel/adapter/src/validate.rs
+++ b/crates/kernel/adapter/src/validate.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
+use ergo_runtime::runtime_version;
 use jsonschema::draft202012;
-use ergo_runtime::RUNTIME_VERSION;
 use regex::Regex;
 use semver::Version;
 use serde_json::Value;
@@ -137,12 +137,13 @@ fn check_adp_3(m: &AdapterManifest) -> Result<(), InvalidAdapter> {
         }
     })?;
 
-    let actual = Version::parse(RUNTIME_VERSION).expect("valid constant");
+    let actual_version = runtime_version();
+    let actual = Version::parse(actual_version).expect("valid constant");
 
     if actual < required {
         return Err(InvalidAdapter::IncompatibleRuntime {
             required: m.runtime_compatibility.clone(),
-            actual: RUNTIME_VERSION.to_string(),
+            actual: actual_version.to_string(),
         });
     }
     Ok(())
@@ -460,20 +461,18 @@ fn schema_is_object(schema: &serde_json::Map<String, Value>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::validate_adapter;
-    use ergo_runtime::RUNTIME_VERSION;
+    use ergo_runtime::runtime_version;
     use serde_json::json;
 
     use crate::errors::InvalidAdapter;
-    use crate::manifest::{
-        AdapterManifest, CaptureSpec, ContextKeySpec, EventKindSpec,
-    };
+    use crate::manifest::{AdapterManifest, CaptureSpec, ContextKeySpec, EventKindSpec};
 
     fn baseline_manifest() -> AdapterManifest {
         AdapterManifest {
             kind: "adapter".to_string(),
             id: "demo".to_string(),
             version: "1.0.0".to_string(),
-            runtime_compatibility: RUNTIME_VERSION.to_string(),
+            runtime_compatibility: runtime_version().to_string(),
             context_keys: vec![ContextKeySpec {
                 name: "x".to_string(),
                 ty: "Number".to_string(),
@@ -521,7 +520,7 @@ mod tests {
         match err {
             InvalidAdapter::IncompatibleRuntime { required, actual } => {
                 assert_eq!(required, "999.0.0");
-                assert_eq!(actual, RUNTIME_VERSION);
+                assert_eq!(actual, runtime_version());
             }
             other => panic!("expected incompatible runtime error, got {other:?}"),
         }

--- a/crates/kernel/runtime/src/lib.rs
+++ b/crates/kernel/runtime/src/lib.rs
@@ -4,6 +4,10 @@
 
 pub const RUNTIME_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+pub fn runtime_version() -> &'static str {
+    RUNTIME_VERSION
+}
+
 pub mod action;
 pub mod catalog;
 pub mod cluster;

--- a/crates/prod/core/host/src/lib.rs
+++ b/crates/prod/core/host/src/lib.rs
@@ -37,14 +37,13 @@ pub use runner::{HostedAdapterConfig, HostedEvent, HostedRunner, HostedStepOutco
 pub use usecases::{
     finalize_hosted_runner_capture, prepare_hosted_runner_from_paths,
     prepare_hosted_runner_from_paths_with_surfaces, replay_graph_from_paths,
-    replay_graph_from_paths_with_surfaces, run_graph_from_paths,
-    run_graph_from_paths_with_control, run_graph_from_paths_with_surfaces,
-    run_graph_from_paths_with_surfaces_and_control, validate_graph_from_paths,
-    validate_graph_from_paths_with_surfaces, AdapterDependencySummary, DriverConfig,
-    HostReplayError, HostRunError, HostStopHandle, InterruptedRun, InterruptionReason,
-    PrepareHostedRunnerFromPathsRequest, ReplayGraphFromPathsRequest, ReplayGraphRequest,
-    ReplayGraphResult, RunControl, RunGraphFromPathsRequest, RunGraphResponse, RunOutcome,
-    RunSummary, RuntimeSurfaces,
+    replay_graph_from_paths_with_surfaces, run_graph_from_paths, run_graph_from_paths_with_control,
+    run_graph_from_paths_with_surfaces, run_graph_from_paths_with_surfaces_and_control,
+    validate_graph_from_paths, validate_graph_from_paths_with_surfaces, AdapterDependencySummary,
+    DriverConfig, HostReplayError, HostRunError, HostStopHandle, InterruptedRun,
+    InterruptionReason, PrepareHostedRunnerFromPathsRequest, ReplayGraphFromPathsRequest,
+    ReplayGraphRequest, ReplayGraphResult, RunControl, RunGraphFromPathsRequest, RunGraphResponse,
+    RunOutcome, RunSummary, RuntimeSurfaces,
 };
 
 // Lower-level host building blocks. These remain public for advanced embedded

--- a/tools/verify_doctrine_gate.sh
+++ b/tools/verify_doctrine_gate.sh
@@ -5,11 +5,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 resolve_docs_root() {
-  if [[ -d "docs_legacy/CANONICAL" ]]; then
-    echo "docs_legacy"
-    return
-  fi
-  if [[ -d "docs/CANONICAL" ]]; then
+  if [[ -d "docs/invariants" ]] && [[ -d "docs/ledger/gap-work/open" ]]; then
     echo "docs"
     return
   fi
@@ -18,66 +14,55 @@ resolve_docs_root() {
 
 DOCS_ROOT="$(resolve_docs_root)"
 if [[ -z "$DOCS_ROOT" ]]; then
-  echo "error: unable to locate docs root (expected docs_legacy/CANONICAL or docs/CANONICAL)"
+  echo "error: unable to locate current docs root (expected docs/invariants and docs/ledger/gap-work/open)"
   exit 1
 fi
 
-LEDGER="${DOCS_ROOT}/CANONICAL/DOCTRINE_GAPS/SUP2_RUNRESULT_ALIGNMENT.md"
+OPEN_GAP_DIR="${DOCS_ROOT}/ledger/gap-work/open"
 CLAIM_PATTERN='canonical complete|full canonical closure'
 
-if [[ ! -f "$LEDGER" ]]; then
-  echo "error: doctrine ledger not found at $LEDGER"
+if [[ ! -d "$OPEN_GAP_DIR" ]]; then
+  echo "error: doctrine open-gap directory not found at $OPEN_GAP_DIR"
   exit 1
 fi
 
-OPEN_ROWS="$(python3 - "$LEDGER" <<'PY'
-import re
+OPEN_GAPS="$(python3 - "$OPEN_GAP_DIR" <<'PY'
 import sys
 from pathlib import Path
 
-ledger = Path(sys.argv[1]).read_text().splitlines()
-open_rows = []
+open_dir = Path(sys.argv[1])
+rows = []
 
-for line in ledger:
-    if not line.strip().startswith("| D"):
+for path in sorted(open_dir.glob("*.md")):
+    if path.name == ".gitkeep":
         continue
-    cells = [cell.strip() for cell in line.split("|")]
-    if len(cells) < 7:
-        continue
-    row_id = cells[1]
-    status = cells[6].upper()
-    if status != "CLOSED":
-        open_rows.append(f"{row_id}:{cells[6]}")
+    rows.append(path.as_posix())
 
-print("\n".join(open_rows))
+print("\n".join(rows))
 PY
 )"
 
-if [[ -n "${OPEN_ROWS}" ]]; then
+if [[ -n "${OPEN_GAPS}" ]]; then
   if command -v rg >/dev/null 2>&1; then
-    SEARCH_ROOTS=("$DOCS_ROOT")
-    if [[ "$DOCS_ROOT" != "docs" && -d "docs" ]]; then
-      SEARCH_ROOTS+=("docs")
-    fi
     if rg -n -i "$CLAIM_PATTERN" \
-      "${SEARCH_ROOTS[@]}" ./*.md \
-      --glob "!${LEDGER}" \
+      docs ./*.md \
+      --glob "!docs/ledger/**" \
       >/tmp/ergo_doctrine_gate_matches.txt 2>/dev/null; then
       echo "error: DOC-GATE-1 violation: canonical-complete claim found with open doctrine gaps"
-      echo "open rows:"
-      echo "$OPEN_ROWS" | sed 's/^/  - /'
+      echo "open gaps:"
+      echo "$OPEN_GAPS" | sed 's/^/  - /'
       echo "matches:"
       cat /tmp/ergo_doctrine_gate_matches.txt
       rm -f /tmp/ergo_doctrine_gate_matches.txt
       exit 1
     fi
   else
-    if grep -Ein "$CLAIM_PATTERN" "${DOCS_ROOT}"/*.md ./*.md \
-      | grep -v "$LEDGER" \
+    if grep -Ein "$CLAIM_PATTERN" docs/**/*.md ./*.md 2>/dev/null \
+      | grep -v "docs/ledger/" \
       >/tmp/ergo_doctrine_gate_matches.txt 2>/dev/null; then
       echo "error: DOC-GATE-1 violation: canonical-complete claim found with open doctrine gaps"
-      echo "open rows:"
-      echo "$OPEN_ROWS" | sed 's/^/  - /'
+      echo "open gaps:"
+      echo "$OPEN_GAPS" | sed 's/^/  - /'
       echo "matches:"
       cat /tmp/ergo_doctrine_gate_matches.txt
       rm -f /tmp/ergo_doctrine_gate_matches.txt

--- a/tools/verify_invariant_index.sh
+++ b/tools/verify_invariant_index.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [[ -z "$PYTHON_BIN" ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
+  elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="python"
+  else
+    echo "error: python interpreter not found (tried python3, python)"
+    exit 1
+  fi
+fi
+
+INVARIANT_INDEX="docs/invariants/INDEX.md"
+if [[ ! -f "$INVARIANT_INDEX" ]]; then
+  echo "error: invariant index not found at $INVARIANT_INDEX"
+  exit 1
+fi
+
+"$PYTHON_BIN" - "$INVARIANT_INDEX" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+index_path = Path(sys.argv[1])
+doc_paths = [index_path, *sorted(index_path.parent.glob("[0-9][0-9]-*.md"))]
+content = index_path.read_text()
+
+header_match = re.search(r"\*\*Tracked invariants:\*\*\s*([0-9]+)", content)
+if not header_match:
+    print("error: missing tracked invariant count header")
+    sys.exit(1)
+
+declared = int(header_match.group(1))
+id_pattern = re.compile(r"^[A-Z][A-Z0-9]*(?:[.-][A-Z0-9]+)*[.-][0-9]+$")
+ids = set()
+
+for doc_path in doc_paths:
+    for raw_line in doc_path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.split("|")]
+        if len(cells) < 3:
+            continue
+        first_cell = cells[1]
+        if first_cell.startswith("~~") and first_cell.endswith("~~") and len(first_cell) > 4:
+            continue
+        for left, right in [("~~", "~~"), ("**", "**"), ("`", "`")]:
+            if first_cell.startswith(left) and first_cell.endswith(right) and len(first_cell) > (len(left) + len(right)):
+                first_cell = first_cell[len(left):len(first_cell) - len(right)].strip()
+        if id_pattern.fullmatch(first_cell):
+            ids.add(first_cell)
+
+parsed = len(ids)
+if parsed != declared:
+    print(f"error: invariant count drift detected (declared={declared}, parsed={parsed})")
+    sys.exit(1)
+
+print(f"invariant index count check passed ({parsed})")
+PY

--- a/tools/verify_replay_naming.sh
+++ b/tools/verify_replay_naming.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if command -v rg >/dev/null 2>&1; then
+  SEARCH_CMD=(rg -n)
+else
+  SEARCH_CMD=(grep -En)
+fi
+
+if "${SEARCH_CMD[@]}" "demo-1-replay\\.json|fixture-replay\\.json|println!\\(\\\"replay artifact:" \
+  crates/prod/clients/cli/src/main.rs \
+  crates/kernel/supervisor/src/fixture_runner.rs \
+  crates/kernel/adapter/src/fixture.rs; then
+  echo "error: stale replay-oriented run artifact naming found"
+  exit 1
+fi
+
+echo "replay naming guard passed"

--- a/tools/verify_runtime_surface.sh
+++ b/tools/verify_runtime_surface.sh
@@ -18,107 +18,32 @@ if [[ -z "$PYTHON_BIN" ]]; then
   fi
 fi
 
-if command -v rg >/dev/null 2>&1; then
-  SEARCH_CMD=(rg -n)
-else
-  SEARCH_CMD=(grep -En)
-fi
-
-resolve_phase_invariants_path() {
-  if [[ -f "docs_legacy/CANONICAL/PHASE_INVARIANTS.md" ]]; then
-    echo "docs_legacy/CANONICAL/PHASE_INVARIANTS.md"
-    return
-  fi
-  if [[ -f "docs/CANONICAL/PHASE_INVARIANTS.md" ]]; then
-    echo "docs/CANONICAL/PHASE_INVARIANTS.md"
-    return
-  fi
-  echo ""
-}
-
-PHASE_INVARIANTS_PATH="$(resolve_phase_invariants_path)"
-if [[ -z "$PHASE_INVARIANTS_PATH" ]]; then
-  echo "error: phase invariants file not found (expected docs_legacy/CANONICAL/PHASE_INVARIANTS.md or docs/CANONICAL/PHASE_INVARIANTS.md)"
-  exit 1
-fi
-
-echo "[1/9] cargo fmt --check"
+echo "[1/8] cargo fmt --check"
 cargo fmt --check
 
-echo "[2/9] cargo test -p ergo-supervisor"
-cargo test -p ergo-supervisor
+echo "[2/8] cargo test --workspace"
+cargo test --workspace
 
-echo "[3/9] cargo test -p ergo-cli"
-cargo test -p ergo-cli
+echo "[3/8] replay-naming drift guard"
+bash tools/verify_replay_naming.sh
 
-echo "[4/9] cargo test"
-cargo test
-
-echo "[5/9] replay-naming drift guard"
-if "${SEARCH_CMD[@]}" "demo-1-replay\\.json|fixture-replay\\.json|println!\\(\\\"replay artifact:" \
-  crates/prod/clients/cli/src/main.rs \
-  crates/kernel/supervisor/src/fixture_runner.rs \
-  crates/kernel/adapter/src/fixture.rs; then
-  echo "error: stale replay-oriented run artifact naming found"
-  exit 1
-fi
-
-echo "[6/10] doctrine gate guard"
+echo "[4/8] doctrine gate guard"
 bash tools/verify_doctrine_gate.sh
 
-echo "[7/10] layer boundary guard"
+echo "[5/8] layer boundary guard"
 bash tools/verify_layer_boundaries.sh
 
-echo "[8/10] phase-invariants count guard"
-"$PYTHON_BIN" - "$PHASE_INVARIANTS_PATH" <<'PY'
-import re
-import sys
-from pathlib import Path
+echo "[6/8] invariant-index count guard"
+bash tools/verify_invariant_index.sh
 
-doc_path = Path(sys.argv[1])
-content = doc_path.read_text()
-
-header_match = re.search(r"\*\*Tracked invariants:\*\*\s*([0-9]+)", content)
-if not header_match:
-    print("error: missing tracked invariant count header")
-    sys.exit(1)
-
-declared = int(header_match.group(1))
-id_pattern = re.compile(r"^[A-Z][A-Z0-9]*(?:[.-][A-Z0-9]+)*[.-][0-9]+$")
-ids = set()
-
-for raw_line in content.splitlines():
-    line = raw_line.strip()
-    if not line.startswith("|"):
-        continue
-    cells = [cell.strip() for cell in line.split("|")]
-    if len(cells) < 3:
-        continue
-    first_cell = cells[1]
-    if first_cell.startswith("~~") and first_cell.endswith("~~") and len(first_cell) > 4:
-        continue
-    for left, right in [("~~", "~~"), ("**", "**"), ("`", "`")]:
-        if first_cell.startswith(left) and first_cell.endswith(right) and len(first_cell) > (len(left) + len(right)):
-            first_cell = first_cell[len(left):len(first_cell) - len(right)].strip()
-    if id_pattern.fullmatch(first_cell):
-        ids.add(first_cell)
-
-parsed = len(ids)
-if parsed != declared:
-    print(f"error: invariant count drift detected (declared={declared}, parsed={parsed})")
-    sys.exit(1)
-
-print(f"phase invariants count check passed ({parsed})")
-PY
-
-echo "[9/10] ergo-mcp invariant parser tests"
+echo "[7/8] ergo-mcp invariant parser tests"
 if [[ -d "tools/ergo-mcp" ]]; then
   "$PYTHON_BIN" -m unittest discover -s tools/ergo-mcp -p "test_*.py"
 else
   echo "skipping ergo-mcp invariant parser tests (tools/ergo-mcp not present)"
 fi
 
-echo "[10/10] windows compile guard (${WINDOWS_TARGET})"
+echo "[8/8] windows compile guard (${WINDOWS_TARGET})"
 HOST_OS="$(uname -s 2>/dev/null || echo unknown)"
 STRICT_WINDOWS_GUARD="${ERGO_STRICT_WINDOWS_GUARD:-0}"
 


### PR DESCRIPTION
## Summary

This PR repairs the `Runtime Surface Verification` workflow so it validates
the current repo structure instead of the removed legacy `docs/CANONICAL`
layout.

## What changed

- split the workflow into focused jobs:
  - doctrine + boundaries
  - rust verify on Ubuntu
  - Windows compile
- update runtime-surface verification to use current doctrine paths
- update doctrine-gate verification to use:
  - `docs/invariants`
  - `docs/ledger/gap-work/open`
- add a dedicated invariant-index count guard
- add a dedicated replay-naming drift guard
- fix a workspace-only compile failure by switching adapter validation to
  use `ergo_runtime::runtime_version()` instead of importing the root
  version constant directly

## Why

The old workflow was failing before it reached useful verification because
its scripts still expected the removed `docs_legacy/CANONICAL` /
`docs/CANONICAL` structure. This change makes the checks match the repo we
actually ship and separates unrelated failure modes into clearer jobs.

## Verification

Ran locally:
- `bash tools/verify_runtime_surface.sh`
- `cargo check --workspace`
