### PR TITLE
hardening: clarify host phase authority and execution seams

### DIFF
--- a/crates/prod/core/host/src/diagnostics.rs
+++ b/crates/prod/core/host/src/diagnostics.rs
@@ -1,0 +1,73 @@
+//! diagnostics
+//!
+//! Purpose:
+//! - Host-owned warning and diagnostic emission. Provides a writer-based
+//!   core so emission logic is testable without capturing stderr.
+//!
+//! Owns:
+//! - The `warning: <message>` output format for egress validation warnings.
+//! - The `emit_warnings` writer-based helper and the thin `emit_warnings_to_stderr`
+//!   production wrapper.
+//!
+//! Does not own:
+//! - Warning types themselves (owned by `egress::validation`).
+//! - Validation logic (owned by `egress::validation` and `runner`).
+//!
+//! Connects to:
+//! - `runner.rs` (`HostedRunner::new()` compatibility path).
+//! - `usecases/live_prep.rs` (orchestration path).
+//!
+//! Safety notes:
+//! - The `warning: <format>` output is a public contract consumed by CLI callers
+//!   that parse stderr. Changes to the format must be coordinated.
+
+use std::fmt::Display;
+use std::io::Write;
+
+/// Emit each warning to `writer` in the standard `warning: <message>` format.
+/// Testable: pass any `Write` impl. For production use, prefer
+/// `emit_warnings_to_stderr`.
+pub(crate) fn emit_warnings<W: Write>(writer: &mut W, warnings: &[impl Display]) {
+    for warning in warnings {
+        let _ = writeln!(writer, "warning: {warning}");
+    }
+}
+
+/// Thin production wrapper: emit warnings to stderr.
+pub(crate) fn emit_warnings_to_stderr(warnings: &[impl Display]) {
+    emit_warnings(&mut std::io::stderr(), warnings);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::egress::EgressValidationWarning;
+
+    #[test]
+    fn emit_warnings_formats_each_warning_on_its_own_line() {
+        let warnings = vec![
+            EgressValidationWarning::RouteForNonEmittableKind {
+                intent_kind: "place_order".to_string(),
+            },
+            EgressValidationWarning::RouteForNonEmittableKind {
+                intent_kind: "cancel_order".to_string(),
+            },
+        ];
+        let mut buf = Vec::new();
+        emit_warnings(&mut buf, &warnings);
+        let output = String::from_utf8(buf).expect("valid utf8");
+        assert_eq!(
+            output,
+            "warning: egress route declared for non-emittable kind 'place_order'\n\
+             warning: egress route declared for non-emittable kind 'cancel_order'\n"
+        );
+    }
+
+    #[test]
+    fn emit_warnings_produces_nothing_for_empty_slice() {
+        let warnings: Vec<EgressValidationWarning> = vec![];
+        let mut buf = Vec::new();
+        emit_warnings(&mut buf, &warnings);
+        assert!(buf.is_empty());
+    }
+}

--- a/crates/prod/core/host/src/lib.rs
+++ b/crates/prod/core/host/src/lib.rs
@@ -29,6 +29,7 @@
 
 mod capture_enrichment;
 mod demo_fixture_usecase;
+mod diagnostics;
 mod egress;
 mod error;
 mod expand_diagnostics;

--- a/crates/prod/core/host/src/runner.rs
+++ b/crates/prod/core/host/src/runner.rs
@@ -29,16 +29,26 @@
 //! - `HostDecisionLog` propagates mutex poison via `expect(...)`; a panic while the lock is held is
 //!   treated as unrecoverable for the runner lifetime.
 //! - `CaptureFinalizationState` is load-bearing: `FinalizeOnly` permits capture finalization but
-//!   blocks further stepping, while `Fatal` blocks both.
-//! - `HostedEvent` intentionally stays a public wire DTO; the private
-//!   `ValidatedHostedEvent` phase is the runner-owned validation boundary before
-//!   adapter binding or external-event construction.
+//!   blocks further stepping, while `Fatal` blocks both. This is the runner-owned
+//!   gate in the capture finalization pipeline:
+//!     runner.rs: `CaptureFinalizationState` (gate), `ensure_capture_finalizable()`,
+//!       `into_capture_bundle()` (extraction)
+//!     live_prep.rs: `HostedRunnerFinalizeFailure` (staged error),
+//!       `finalize_hosted_runner_capture_with_stage()` (3-step orchestration)
+//!     live_run.rs: `FinalizedRunCapture` (summary DTO),
+//!       `finalize_run_capture()` (driver-level validation)
+//! - `HostedEvent` intentionally stays in this file as the public wire DTO
+//!   consumed by CLI/SDK callers. The typing boundary is the private
+//!   `ValidatedHostedEvent` phase, not the wire shape. `semantic_kind` remains
+//!   `Option<String>` for wire compatibility; validation of semantic-kind
+//!   coherence happens during adapter binding, not at the DTO level.
 //! - `host_internal_handler_kinds()` is the host-owned authority for effect
 //!   kinds that stay inside the runner/handler path rather than replay-owned
 //!   external effects.
-//! - Non-fatal egress validation warnings currently surface through an explicit
-//!   stderr helper because the host has no structured warning sink at this
-//!   layer.
+//! - `validate_hosted_runner_configuration()` is a pure validation function
+//!   that returns warnings as data. `HostedRunner::new()` emits warnings to
+//!   stderr to preserve behavior for direct callers; orchestration callers
+//!   (e.g. `live_prep.rs`) handle warnings at their own layer.
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::{Arc, Mutex};
@@ -62,6 +72,7 @@ use crate::capture_enrichment::{
     enrich_bundle_with_host_artifacts, AppliedEffectsByDecision, AppliedIntentAcksByDecision,
     StepInterruptionsByDecision,
 };
+use crate::diagnostics::emit_warnings_to_stderr;
 use crate::egress::{
     validate_egress_config, EgressConfig, EgressProcessError, EgressRuntime,
     EgressValidationWarning,
@@ -232,6 +243,44 @@ enum CaptureFinalizationState {
     Fatal,
 }
 
+/// Domain-shaped transition methods. Each method represents a specific
+/// lifecycle event rather than a generic state target, so call sites
+/// cannot request meaningless moves.
+///
+/// Legal transitions:
+/// - `NoCommittedSteps → Eligible`   (on_step_success)
+/// - `NoCommittedSteps → FinalizeOnly` (on_dispatch_failure)
+/// - `NoCommittedSteps → Fatal`      (on_fatal_error)
+/// - `Eligible → FinalizeOnly`       (on_dispatch_failure)
+/// - `Eligible → Fatal`              (on_fatal_error)
+/// - `FinalizeOnly → Fatal`          (on_fatal_error)
+impl CaptureFinalizationState {
+    /// A step executed successfully. `NoCommittedSteps → Eligible` on first
+    /// call; idempotent once `Eligible`. `FinalizeOnly`/`Fatal` are unreachable
+    /// here (guarded by `ensure_step_allowed`) but preserved defensively.
+    fn on_step_success(self) -> Self {
+        match self {
+            Self::NoCommittedSteps => Self::Eligible,
+            other => other,
+        }
+    }
+
+    /// An egress dispatch failure occurred. Moves to `FinalizeOnly`.
+    /// Legal from `NoCommittedSteps` and `Eligible`. Idempotent from
+    /// `FinalizeOnly`. `Fatal` is preserved (already terminal).
+    fn on_dispatch_failure(self) -> Self {
+        match self {
+            Self::Fatal => Self::Fatal,
+            _ => Self::FinalizeOnly,
+        }
+    }
+
+    /// A non-recoverable error occurred. Always moves to `Fatal`.
+    fn on_fatal_error(self) -> Self {
+        Self::Fatal
+    }
+}
+
 pub(crate) const HOST_INTERNAL_SET_CONTEXT_KIND: &str = "set_context";
 
 fn default_handlers() -> BTreeMap<String, Arc<dyn EffectHandler>> {
@@ -253,7 +302,7 @@ pub(crate) fn validate_hosted_runner_configuration(
     egress_provenance: Option<&str>,
     replay_external_kinds: &HashSet<String>,
     graph_emittable_effect_kinds: &HashSet<String>,
-) -> Result<(), HostedStepError> {
+) -> Result<Vec<EgressValidationWarning>, HostedStepError> {
     let handler_kinds = host_internal_handler_kinds();
 
     if egress_config.is_some() && !replay_external_kinds.is_empty() {
@@ -273,15 +322,16 @@ pub(crate) fn validate_hosted_runner_configuration(
         ));
     }
 
+    let mut warnings = Vec::new();
+
     if let Some(config) = adapter {
         if let Some(egress_config) = egress_config {
-            let warnings = validate_egress_config(
+            warnings = validate_egress_config(
                 egress_config,
                 &config.provides,
                 graph_emittable_effect_kinds,
                 &handler_kinds,
             )?;
-            emit_egress_validation_warnings_to_stderr(&warnings);
         } else {
             ensure_handler_coverage(
                 &config.provides,
@@ -311,7 +361,7 @@ pub(crate) fn validate_hosted_runner_configuration(
         ));
     }
 
-    Ok(())
+    Ok(warnings)
 }
 
 pub struct HostedRunner {
@@ -366,13 +416,14 @@ impl HostedRunner {
     ) -> Result<Self, HostedStepError> {
         let graph_emittable_effect_kinds = runtime.graph_emittable_effect_kinds();
         let replay_external_kinds = replay_external_kinds.unwrap_or_default();
-        validate_hosted_runner_configuration(
+        let warnings = validate_hosted_runner_configuration(
             adapter.as_ref(),
             egress_config.as_ref(),
             egress_provenance.as_deref(),
             &replay_external_kinds,
             &graph_emittable_effect_kinds,
         )?;
+        emit_warnings_to_stderr(&warnings);
 
         Ok(Self::new_validated(
             graph_id,
@@ -468,7 +519,7 @@ impl HostedRunner {
         let outcome = self.execute_step(external_event, mode);
         match &outcome {
             Ok(_) => {
-                self.capture_finalization_state = CaptureFinalizationState::Eligible;
+                self.capture_finalization_state = self.capture_finalization_state.on_step_success();
             }
             Err(err) => self.record_step_error(err),
         }
@@ -651,15 +702,13 @@ impl HostedRunner {
     }
 
     fn record_step_error(&mut self, err: &HostedStepError) {
-        match err {
+        self.capture_finalization_state = match err {
             HostedStepError::EgressDispatchFailure(_) => {
-                self.capture_finalization_state = CaptureFinalizationState::FinalizeOnly;
+                self.capture_finalization_state.on_dispatch_failure()
             }
-            err if is_recoverable_hosted_step_error(err) => {}
-            _ => {
-                self.capture_finalization_state = CaptureFinalizationState::Fatal;
-            }
-        }
+            err if is_recoverable_hosted_step_error(err) => self.capture_finalization_state,
+            _ => self.capture_finalization_state.on_fatal_error(),
+        };
     }
 
     fn build_external_event(&self, event: HostedEvent) -> Result<ExternalEvent, HostedStepError> {
@@ -874,12 +923,6 @@ fn allowed_schema_keys(
     }
 
     Ok(keys)
-}
-
-fn emit_egress_validation_warnings_to_stderr(warnings: &[EgressValidationWarning]) {
-    for warning in warnings {
-        eprintln!("warning: {warning}");
-    }
 }
 
 #[cfg(test)]

--- a/crates/prod/core/host/src/runner/tests.rs
+++ b/crates/prod/core/host/src/runner/tests.rs
@@ -1389,3 +1389,163 @@ fn fatal_step_error_is_sticky_for_future_steps_and_finalization() {
         HostedStepError::LifecycleViolation { .. }
     ));
 }
+
+#[test]
+fn validate_hosted_runner_configuration_returns_warnings_as_data() {
+    // Scenario: adapter accepts `place_order`, egress routes `place_order`,
+    // but the graph (number_source) has no action nodes so it cannot emit
+    // `place_order`. The route is valid but non-emittable → warning.
+    let provides = adapter_provides_with_effects(&["place_order"]);
+    let runtime = runtime_for_graph(build_number_source_graph(), provides.clone());
+    let adapter = adapter_config(provides);
+    let egress_config = EgressConfig::builder(Duration::from_millis(50))
+        .channel(
+            "broker",
+            EgressChannelConfig::process(vec!["echo".to_string()])
+                .expect("channel config should be valid"),
+        )
+        .expect("channel should insert")
+        .route(
+            "place_order",
+            EgressRoute::new("broker", None).expect("route should be valid"),
+        )
+        .expect("route should insert")
+        .build()
+        .expect("egress config should build");
+
+    let graph_emittable = runtime.graph_emittable_effect_kinds();
+
+    // Pure validation returns warnings as data — no stderr emission.
+    let warnings = validate_hosted_runner_configuration(
+        Some(&adapter),
+        Some(&egress_config),
+        Some("epv1:sha256:test"),
+        &HashSet::new(),
+        &graph_emittable,
+    )
+    .expect("validation should pass with non-emittable route as warning");
+
+    assert_eq!(warnings.len(), 1, "expected exactly one warning");
+    assert!(
+        matches!(
+            &warnings[0],
+            crate::egress::EgressValidationWarning::RouteForNonEmittableKind { intent_kind }
+            if intent_kind == "place_order"
+        ),
+        "expected RouteForNonEmittableKind warning for place_order, got {warnings:?}"
+    );
+}
+
+#[test]
+fn hosted_runner_new_succeeds_with_non_emittable_egress_route_warnings() {
+    // Same scenario as above, but through the public HostedRunner::new() path.
+    // Verifies that non-fatal warnings don't block construction — the compatibility
+    // contract for direct CLI/SDK callers.
+    let provides = adapter_provides_with_effects(&["place_order"]);
+    let runtime = runtime_for_graph(build_number_source_graph(), provides.clone());
+    let adapter = adapter_config(provides);
+    let egress_config = EgressConfig::builder(Duration::from_millis(50))
+        .channel(
+            "broker",
+            EgressChannelConfig::process(vec!["echo".to_string()])
+                .expect("channel config should be valid"),
+        )
+        .expect("channel should insert")
+        .route(
+            "place_order",
+            EgressRoute::new("broker", None).expect("route should be valid"),
+        )
+        .expect("route should insert")
+        .build()
+        .expect("egress config should build");
+
+    // HostedRunner::new() must succeed — warnings are emitted to stderr
+    // but do not block construction.
+    let _runner = HostedRunner::new(
+        GraphId::new("g"),
+        Constraints::default(),
+        runtime,
+        "runtime:test".to_string(),
+        Some(adapter),
+        Some(egress_config),
+        Some("epv1:sha256:test".to_string()),
+        None,
+    )
+    .expect("runner construction must not fail due to non-emittable route warnings");
+}
+
+// --- CaptureFinalizationState domain transition contract tests ---
+
+#[test]
+fn capture_finalization_on_step_success_from_no_committed_steps() {
+    let state = CaptureFinalizationState::NoCommittedSteps;
+    assert_eq!(state.on_step_success(), CaptureFinalizationState::Eligible);
+}
+
+#[test]
+fn capture_finalization_on_step_success_idempotent_from_eligible() {
+    let state = CaptureFinalizationState::Eligible;
+    assert_eq!(state.on_step_success(), CaptureFinalizationState::Eligible);
+}
+
+#[test]
+fn capture_finalization_on_step_success_preserves_finalize_only() {
+    // FinalizeOnly is unreachable on success path (guarded by ensure_step_allowed),
+    // but the method defensively preserves the state.
+    let state = CaptureFinalizationState::FinalizeOnly;
+    assert_eq!(
+        state.on_step_success(),
+        CaptureFinalizationState::FinalizeOnly
+    );
+}
+
+#[test]
+fn capture_finalization_on_step_success_preserves_fatal() {
+    let state = CaptureFinalizationState::Fatal;
+    assert_eq!(state.on_step_success(), CaptureFinalizationState::Fatal);
+}
+
+#[test]
+fn capture_finalization_on_dispatch_failure_from_no_committed_steps() {
+    let state = CaptureFinalizationState::NoCommittedSteps;
+    assert_eq!(
+        state.on_dispatch_failure(),
+        CaptureFinalizationState::FinalizeOnly
+    );
+}
+
+#[test]
+fn capture_finalization_on_dispatch_failure_from_eligible() {
+    let state = CaptureFinalizationState::Eligible;
+    assert_eq!(
+        state.on_dispatch_failure(),
+        CaptureFinalizationState::FinalizeOnly
+    );
+}
+
+#[test]
+fn capture_finalization_on_dispatch_failure_idempotent_from_finalize_only() {
+    let state = CaptureFinalizationState::FinalizeOnly;
+    assert_eq!(
+        state.on_dispatch_failure(),
+        CaptureFinalizationState::FinalizeOnly
+    );
+}
+
+#[test]
+fn capture_finalization_on_dispatch_failure_preserves_fatal() {
+    let state = CaptureFinalizationState::Fatal;
+    assert_eq!(state.on_dispatch_failure(), CaptureFinalizationState::Fatal);
+}
+
+#[test]
+fn capture_finalization_on_fatal_error_from_all_states() {
+    for state in [
+        CaptureFinalizationState::NoCommittedSteps,
+        CaptureFinalizationState::Eligible,
+        CaptureFinalizationState::FinalizeOnly,
+        CaptureFinalizationState::Fatal,
+    ] {
+        assert_eq!(state.on_fatal_error(), CaptureFinalizationState::Fatal);
+    }
+}

--- a/crates/prod/core/host/src/usecases.rs
+++ b/crates/prod/core/host/src/usecases.rs
@@ -990,6 +990,9 @@ impl InterruptionReason {
     }
 }
 
+/// Display delegates to `code()`. This is a public contract consumed by CLI
+/// and SDK callers that pattern-match on the formatted output. Locked by
+/// `interruption_reason_code_and_display_contract_is_locked` in contract tests.
 impl std::fmt::Display for InterruptionReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.code())
@@ -1290,23 +1293,6 @@ pub struct RunGraphFromAssetsRequest {
     pub capture: CapturePolicy,
 }
 
-pub(super) struct PreparedLiveRunnerSetup {
-    adapter_bound: bool,
-    dependency_summary: AdapterDependencySummary,
-    runner: HostedRunner,
-}
-
-struct ValidatedLiveRunnerSetup {
-    graph_id: GraphId,
-    runtime_provenance: String,
-    runtime: RuntimeHandle,
-    adapter_config: Option<HostedAdapterConfig>,
-    egress_config: Option<EgressConfig>,
-    egress_provenance: Option<String>,
-    adapter_bound: bool,
-    dependency_summary: AdapterDependencySummary,
-}
-
 #[derive(Debug)]
 pub struct ReplayGraphResult {
     pub graph_id: GraphId,
@@ -1374,12 +1360,6 @@ pub use self::live_run::{
     run_graph_from_paths_with_surfaces_and_control, run_graph_with_control,
 };
 
-use self::live_prep::{
-    ensure_adapter_requirement_satisfied, ensure_production_adapter_bound,
-    finalize_hosted_runner_capture_with_stage, prepare_live_runner_setup_from_assets,
-    session_intent_from_driver, start_live_runner_egress, HostedRunnerFinalizeFailure,
-};
-use self::live_run::{validate_driver_input, DriverExecution, DriverTerminal, RunLifecycleState};
 use self::process_driver::{
     run_process_driver, validate_process_driver_command, ProcessDriverPolicy,
     DEFAULT_PROCESS_DRIVER_POLICY,

--- a/crates/prod/core/host/src/usecases/live_prep.rs
+++ b/crates/prod/core/host/src/usecases/live_prep.rs
@@ -38,6 +38,10 @@
 //!   currently preserve typed `HostedStepError` at the public run boundary:
 //!   it keeps the finalization phases explicit so future host decisions do not
 //!   have to rediscover where pending-ack versus stop-egress failures split.
+//!   This module owns the 3-step staged orchestration in the capture finalization
+//!   pipeline (check → stop egress → extract bundle). The runner-owned gate
+//!   (`CaptureFinalizationState`) lives in `runner.rs`; the driver-level
+//!   validation and summary DTO live in `live_run.rs`.
 //! - Replay representability checks intentionally treat `set_context` as the
 //!   host-internal handler effect path and exclude it from replay-owned
 //!   external kinds.
@@ -54,8 +58,54 @@
 
 #![allow(clippy::arc_with_non_send_sync)]
 
-use super::*;
+// Shared standard-library and external-crate prelude for usecase submodules.
+use super::shared::*;
+// Usecases-owned types used by this module.
+use super::{
+    scan_adapter_dependencies, summarize_expand_error, validate_adapter_composition,
+    AdapterDependencySummary, AdapterInput, DriverConfig, HostAdapterSetupError,
+    HostGraphPreparationError, HostReplayError, HostReplaySetupError, HostRunError, HostSetupError,
+    LivePrepOptions, PrepareHostedRunnerFromPathsRequest, ReplayGraphFromAssetsRequest,
+    ReplayGraphFromPathsRequest, ReplayGraphRequest, ReplayGraphResult, RunGraphFromAssetsRequest,
+    RunGraphFromPathsRequest, RuntimeSurfaces, SessionIntent,
+};
+// Sibling module types.
+use super::live_run::{replay_graph, validate_driver_input};
+// Crate-internal helpers.
+use crate::diagnostics::emit_warnings_to_stderr;
 use crate::runner::host_internal_handler_kinds;
+
+pub(super) struct PreparedLiveRunnerSetup {
+    adapter_bound: bool,
+    dependency_summary: AdapterDependencySummary,
+    runner: HostedRunner,
+}
+
+impl PreparedLiveRunnerSetup {
+    pub(super) fn adapter_bound(&self) -> bool {
+        self.adapter_bound
+    }
+
+    pub(super) fn dependency_summary(&self) -> &AdapterDependencySummary {
+        &self.dependency_summary
+    }
+
+    /// Consume the setup, yielding the hosted runner for the run phase.
+    pub(super) fn into_runner(self) -> HostedRunner {
+        self.runner
+    }
+}
+
+struct ValidatedLiveRunnerSetup {
+    graph_id: GraphId,
+    runtime_provenance: String,
+    runtime: RuntimeHandle,
+    adapter_config: Option<HostedAdapterConfig>,
+    egress_config: Option<EgressConfig>,
+    egress_provenance: Option<String>,
+    adapter_bound: bool,
+    dependency_summary: AdapterDependencySummary,
+}
 
 fn map_live_prep_loader_result(
     result: Result<ergo_loader::PreparedGraphAssets, ergo_loader::LoaderError>,
@@ -355,7 +405,7 @@ fn validate_live_runner_setup_from_assets(
         .as_ref()
         .map(compute_egress_provenance);
     let graph_emittable_effect_kinds = runtime.graph_emittable_effect_kinds();
-    validate_hosted_runner_configuration(
+    let warnings = validate_hosted_runner_configuration(
         adapter_setup.adapter_config.as_ref(),
         options.egress_config.as_ref(),
         egress_provenance.as_deref(),
@@ -363,6 +413,7 @@ fn validate_live_runner_setup_from_assets(
         &graph_emittable_effect_kinds,
     )
     .map_err(hosted_runner_setup_error)?;
+    emit_warnings_to_stderr(&warnings);
 
     Ok(ValidatedLiveRunnerSetup {
         graph_id: GraphId::new(graph_id),
@@ -626,8 +677,7 @@ fn validate_run_graph_internal(
 ) -> Result<(), HostRunError> {
     let validated = validate_live_runner_setup_from_assets(assets, options, runtime_surfaces)?;
     ensure_production_adapter_bound(validated.adapter_bound, session_intent_from_driver(driver))?;
-    validate_driver_input(driver, validated.adapter_bound)?;
-    Ok(())
+    validate_driver_input(driver, validated.adapter_bound).map(|_| ())
 }
 
 fn load_capture_bundle_from_path(capture_path: &Path) -> Result<CaptureBundle, HostReplayError> {

--- a/crates/prod/core/host/src/usecases/live_run.rs
+++ b/crates/prod/core/host/src/usecases/live_run.rs
@@ -35,11 +35,42 @@
 //!   `invoked`/`deferred` come from finalized capture truth.
 //! - The current `InterruptionReason` Display/Debug contract is downstream-significant, but tests
 //!   for that enum belong with its definition in `usecases.rs`, not here.
+//! - `RunLifecycleState` is owned by this module and shared with
+//!   `process_driver.rs` via `pub(super)` function parameter. This module
+//!   owns the lifecycle policy (bounded-run limits, host stop); the process
+//!   driver consumes it to decide when to stop reading events.
+//! - The fixture step loop (`run_fixture_items_driver`) and the process driver
+//!   step loop (`process_driver.rs`) share the same commit/interrupt outcome
+//!   routing pattern but are structurally different ingress protocols (nested
+//!   episode→event iteration vs. streaming message parsing). Unifying them
+//!   would require a trait/callback abstraction that adds indirection without
+//!   reducing meaningful risk. The duplication is structural, not accidental.
 
 // Allow non-Send/Sync in Arc: CoreRegistries and CorePrimitiveCatalog contain non-Send/Sync types.
 #![allow(clippy::arc_with_non_send_sync)]
 
-use super::*;
+use super::live_prep::{
+    ensure_adapter_requirement_satisfied, ensure_production_adapter_bound,
+    finalize_hosted_runner_capture_with_stage, load_graph_assets_from_paths,
+    prepare_live_runner_setup_from_assets, session_intent_from_driver, start_live_runner_egress,
+    HostedRunnerFinalizeFailure,
+};
+// Shared standard-library and external-crate prelude for usecase submodules.
+use super::shared::*;
+// Usecases-owned types used by this module.
+use super::{
+    interruption_from_egress_dispatch_failure, AdapterDependencySummary, AdapterInput,
+    CapturePolicy, DriverConfig, HostDriverError, HostDriverInputError, HostDriverOutputError,
+    HostReplayError, HostRunError, InterruptedRun, InterruptionReason, LivePrepOptions,
+    ReplayGraphRequest, ReplayGraphResult, RunControl, RunFixtureRequest, RunFixtureResult,
+    RunGraphFromAssetsRequest, RunGraphFromPathsRequest, RunGraphRequest, RunGraphResponse,
+    RunOutcome, RunSummary, RuntimeSurfaces,
+};
+// Process driver types (sibling module, imported through parent).
+use super::{
+    run_process_driver, validate_process_driver_command, ProcessDriverPolicy,
+    DEFAULT_PROCESS_DRIVER_POLICY,
+};
 use std::ops::ControlFlow;
 
 pub(super) enum DriverTerminal {
@@ -103,7 +134,7 @@ struct PreparedFixtureEpisode {
 }
 
 #[derive(Debug)]
-struct PreparedFixtureInput {
+pub(super) struct PreparedFixtureInput {
     episodes: Vec<PreparedFixtureEpisode>,
 }
 
@@ -383,11 +414,7 @@ pub(super) fn run_graph_from_paths_internal(
         session_intent: session_intent_from_driver(&driver),
     };
 
-    let PreparedLiveRunnerSetup {
-        adapter_bound,
-        dependency_summary,
-        runner,
-    } = prepare_live_runner_setup_from_assets(&assets, &options, runtime_surfaces)?;
+    let setup = prepare_live_runner_setup_from_assets(&assets, &options, runtime_surfaces)?;
 
     run_graph_with_policy(
         RunGraphRequest {
@@ -395,9 +422,9 @@ pub(super) fn run_graph_from_paths_internal(
             driver,
             capture_output,
             pretty_capture,
-            adapter_bound,
-            dependency_summary,
-            runner,
+            adapter_bound: setup.adapter_bound(),
+            dependency_summary: setup.dependency_summary().clone(),
+            runner: setup.into_runner(),
         },
         process_policy,
         control,
@@ -462,10 +489,20 @@ pub fn run_graph_from_assets_with_surfaces_and_control(
     )
 }
 
+/// Validated driver input. Produced by `validate_driver_input` and consumed by
+/// the execution path, so fixture preparation happens exactly once.
+pub(super) enum ValidatedDriverInput {
+    Fixture(PreparedFixtureInput),
+    Process { command: Vec<String> },
+}
+
+/// Validate driver input and produce a `ValidatedDriverInput` that the execution
+/// path can consume directly. Fixture items are parsed and prepared once here;
+/// the run path no longer needs to repeat that work.
 pub(super) fn validate_driver_input(
     driver: &DriverConfig,
     adapter_bound: bool,
-) -> Result<(), HostRunError> {
+) -> Result<ValidatedDriverInput, HostRunError> {
     match driver {
         DriverConfig::Fixture { path } => {
             let fixture_items = fixture::parse_fixture(path).map_err(|err| {
@@ -473,16 +510,27 @@ pub(super) fn validate_driver_input(
                     err,
                 )))
             })?;
-            validate_fixture_items_input(&fixture_items, &path.display().to_string(), adapter_bound)
-                .map_err(|err| HostRunError::Driver(HostDriverError::Input(err)))
+            PreparedFixtureInput::from_items(
+                fixture_items.into_iter(),
+                &path.display().to_string(),
+                adapter_bound,
+            )
+            .map(ValidatedDriverInput::Fixture)
+            .map_err(|err| HostRunError::Driver(HostDriverError::Input(err)))
         }
         DriverConfig::FixtureItems {
             items,
             source_label,
-        } => validate_fixture_items_input(items, source_label, adapter_bound)
+        } => PreparedFixtureInput::from_items(items.iter().cloned(), source_label, adapter_bound)
+            .map(ValidatedDriverInput::Fixture)
             .map_err(|err| HostRunError::Driver(HostDriverError::Input(err))),
-        DriverConfig::Process { command } => validate_process_driver_command(command)
-            .map_err(|err| HostRunError::Driver(HostDriverError::Input(err))),
+        DriverConfig::Process { command } => {
+            validate_process_driver_command(command)
+                .map_err(|err| HostRunError::Driver(HostDriverError::Input(err)))?;
+            Ok(ValidatedDriverInput::Process {
+                command: command.clone(),
+            })
+        }
     }
 }
 
@@ -498,16 +546,12 @@ pub(super) fn run_graph_from_assets_internal(
         driver,
         capture,
     } = request;
-    let PreparedLiveRunnerSetup {
-        adapter_bound,
-        dependency_summary,
-        runner,
-    } = prepare_live_runner_setup_from_assets(&assets, &prep, runtime_surfaces)?;
+    let setup = prepare_live_runner_setup_from_assets(&assets, &prep, runtime_surfaces)?;
     run_prepared_graph_with_policy(
         driver,
-        adapter_bound,
-        dependency_summary,
-        runner,
+        setup.adapter_bound(),
+        setup.dependency_summary().clone(),
+        setup.into_runner(),
         capture,
         process_policy,
         control,
@@ -537,15 +581,6 @@ fn run_graph_with_policy(
         process_policy,
         control,
     )
-}
-
-fn validate_fixture_items_input(
-    fixture_items: &[fixture::FixtureItem],
-    source_label: &str,
-    adapter_bound: bool,
-) -> Result<(), HostDriverInputError> {
-    PreparedFixtureInput::from_items(fixture_items.iter().cloned(), source_label, adapter_bound)
-        .map(|_| ())
 }
 
 fn run_prepared_graph_with_policy(
@@ -609,53 +644,32 @@ fn execute_run_graph_with_policy(
     ensure_adapter_requirement_satisfied(adapter_bound, &dependency_summary)?;
     ensure_production_adapter_bound(adapter_bound, session_intent_from_driver(&driver))?;
 
+    // Validate and prepare driver input once. The validated input carries any
+    // prepared fixture state so the run path does not re-parse or re-prepare.
+    let validated_input = validate_driver_input(&driver, adapter_bound)?;
+
     start_live_runner_egress(&mut runner)?;
 
     let lifecycle = RunLifecycleState::new(control);
 
-    match driver {
-        DriverConfig::Fixture { path } => {
-            run_fixture_driver(path, adapter_bound, runner, &lifecycle)
+    match validated_input {
+        ValidatedDriverInput::Fixture(prepared) => {
+            run_prepared_fixture_driver(prepared, runner, &lifecycle)
         }
-        DriverConfig::FixtureItems {
-            items,
-            source_label,
-        } => run_fixture_items_driver(items, &source_label, adapter_bound, runner, &lifecycle),
-        DriverConfig::Process { command } => {
+        ValidatedDriverInput::Process { command } => {
             run_process_driver(command, runner, process_policy, &lifecycle)
         }
     }
 }
 
-fn run_fixture_driver(
-    fixture_path: PathBuf,
-    adapter_bound: bool,
+/// Execute a fixture driver with already-prepared input. The preparation
+/// (parsing, validation, episode grouping) was done in `validate_driver_input`,
+/// so this function consumes the result directly — no re-parsing or re-preparation.
+fn run_prepared_fixture_driver(
+    prepared: PreparedFixtureInput,
     runner: HostedRunner,
     lifecycle: &RunLifecycleState,
 ) -> Result<DriverExecution, HostRunError> {
-    let fixture_items = fixture::parse_fixture(&fixture_path).map_err(|err| {
-        HostRunError::Driver(HostDriverError::Input(HostDriverInputError::FixtureParse(
-            err,
-        )))
-    })?;
-    run_fixture_items_driver(
-        fixture_items,
-        &fixture_path.display().to_string(),
-        adapter_bound,
-        runner,
-        lifecycle,
-    )
-}
-
-fn run_fixture_items_driver(
-    fixture_items: Vec<fixture::FixtureItem>,
-    source_label: &str,
-    adapter_bound: bool,
-    runner: HostedRunner,
-    lifecycle: &RunLifecycleState,
-) -> Result<DriverExecution, HostRunError> {
-    let prepared = PreparedFixtureInput::from_items(fixture_items, source_label, adapter_bound)
-        .map_err(|err| HostRunError::Driver(HostDriverError::Input(err)))?;
     let mut state = FixtureDriverState::new(runner, &prepared);
 
     for (episode_index, episode) in prepared.episodes.into_iter().enumerate() {

--- a/crates/prod/core/host/src/usecases/process_driver.rs
+++ b/crates/prod/core/host/src/usecases/process_driver.rs
@@ -39,10 +39,28 @@
 //!   instead of collapsing back into the old `HostRunError` string variants.
 //! - On Unix, abort kills the host-managed process group configured during
 //!   spawn, not just the direct child.
+//! - The process driver step loop and the fixture driver step loop in
+//!   `live_run.rs` share the same commit/interrupt outcome routing but are
+//!   structurally different ingress protocols. See `live_run.rs` header for
+//!   the design rationale on keeping them separate.
 
-use super::*;
-
+use super::live_run::{DriverExecution, DriverTerminal, RunLifecycleState};
+use super::{
+    interruption_from_egress_dispatch_failure, HostDriverError, HostDriverInputError,
+    HostDriverIoError, HostDriverOutputError, HostDriverProtocolError, HostDriverStartError,
+    HostRunError, InterruptionReason,
+};
+use crate::{HostedEvent, HostedRunner, PROCESS_DRIVER_PROTOCOL_VERSION};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{BufRead, BufReader, Read};
 use std::ops::ControlFlow;
+use std::path::Path;
+use std::process::{Child, ChildStdout, Command, ExitStatus, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
@@ -113,6 +131,10 @@ enum ProcessDriverCommitPhase {
     AfterFirstCommittedStep,
 }
 
+/// Synthetic episode label for `ergo-driver.v0`, which has no episode-boundary
+/// frame. All events are attributed to a single episode with this label.
+const V0_SINGLE_EPISODE_LABEL: &str = "E1";
+
 #[derive(Debug)]
 enum ProcessDriverEpisodeLedger {
     V0SingleEpisode { event_count: usize },
@@ -132,7 +154,9 @@ impl ProcessDriverEpisodeLedger {
     fn into_episode_event_counts(self) -> Vec<(String, usize)> {
         match self {
             Self::V0SingleEpisode { event_count: 0 } => Vec::new(),
-            Self::V0SingleEpisode { event_count } => vec![("E1".to_string(), event_count)],
+            Self::V0SingleEpisode { event_count } => {
+                vec![(V0_SINGLE_EPISODE_LABEL.to_string(), event_count)]
+            }
         }
     }
 }
@@ -184,6 +208,22 @@ impl ProcessDriverProgress {
     }
 }
 
+/// Composed state machine for the process-driver protocol loop.
+///
+/// Three independent axes tracked simultaneously:
+/// - **Wire phase** (`ProcessDriverWirePhase`): `AwaitingHello` → `StreamingEvents`.
+///   Controls startup timeout behavior and hello-first protocol enforcement.
+/// - **Commit phase** (`ProcessDriverCommitPhase` inside `progress`):
+///   `BeforeFirstCommittedStep` → `AfterFirstCommittedStep`. This is the semantic
+///   boundary that determines whether failures become `HostRunError` (startup) or
+///   `DriverExecution::Interrupted` (partial capture). Transitions on first
+///   successful `runner.step()`.
+/// - **Episode ledger** (`ProcessDriverEpisodeLedger` inside `progress`):
+///   `V0SingleEpisode(count)`. The v0 protocol has no episode-boundary frame, so
+///   all events are attributed to a single synthetic episode.
+///
+/// Initial state: `AwaitingHello × BeforeFirstCommittedStep × V0SingleEpisode(0)`.
+/// Only `StreamingEvents` can host a transition to `AfterFirstCommittedStep`.
 struct ProcessDriverLoopState {
     runner: HostedRunner,
     progress: ProcessDriverProgress,
@@ -246,6 +286,21 @@ impl ProcessDriverLoopState {
         }
     }
 
+    /// Terminal failure routing: before first committed step → startup error,
+    /// after first committed step → interrupted execution with partial capture.
+    fn into_terminal_failure(
+        self,
+        reason: InterruptionReason,
+        before_commit_error: impl FnOnce() -> HostRunError,
+    ) -> Result<DriverExecution, HostRunError> {
+        match self.commit_phase() {
+            ProcessDriverCommitPhase::BeforeFirstCommittedStep => Err(before_commit_error()),
+            ProcessDriverCommitPhase::AfterFirstCommittedStep => {
+                Ok(self.into_execution(DriverTerminal::Interrupted(reason)))
+            }
+        }
+    }
+
     fn into_host_stop_execution(
         self,
         child: &mut Child,
@@ -269,24 +324,27 @@ impl ProcessDriverLoopState {
     }
 }
 
-fn process_driver_host_stop_execution(
-    state: ProcessDriverLoopState,
-    child: &mut Child,
-    stderr_handle: &mut Option<JoinHandle<String>>,
-) -> Result<DriverExecution, HostRunError> {
-    state.into_host_stop_execution(child, stderr_handle)
-}
-
-fn maybe_process_driver_host_stop(
+/// Single host-stop authority for the process-driver loop. Checks lifecycle,
+/// and if a stop is requested, consumes state and returns the stop execution.
+/// If no stop is needed, returns the state unchanged via `Continue`.
+///
+/// Every call site matches explicitly:
+/// ```ignore
+/// state = match check_host_stop(state, &mut child, &mut stderr_handle, lifecycle) {
+///     ControlFlow::Continue(s) => s,
+///     ControlFlow::Break(result) => return result,
+/// };
+/// ```
+fn check_host_stop(
     state: ProcessDriverLoopState,
     child: &mut Child,
     stderr_handle: &mut Option<JoinHandle<String>>,
     lifecycle: &RunLifecycleState,
-) -> Result<ControlFlow<DriverExecution, ProcessDriverLoopState>, HostRunError> {
+) -> ControlFlow<Result<DriverExecution, HostRunError>, ProcessDriverLoopState> {
     if lifecycle.should_stop(state.committed_event_count()) {
-        process_driver_host_stop_execution(state, child, stderr_handle).map(ControlFlow::Break)
+        ControlFlow::Break(state.into_host_stop_execution(child, stderr_handle))
     } else {
-        Ok(ControlFlow::Continue(state))
+        ControlFlow::Continue(state)
     }
 }
 
@@ -351,12 +409,10 @@ pub(super) fn run_process_driver(
     let mut state = ProcessDriverLoopState::new(runner, process_policy);
 
     loop {
-        state =
-            match maybe_process_driver_host_stop(state, &mut child, &mut stderr_handle, lifecycle)?
-            {
-                ControlFlow::Break(execution) => return Ok(execution),
-                ControlFlow::Continue(state) => state,
-            };
+        state = match check_host_stop(state, &mut child, &mut stderr_handle, lifecycle) {
+            ControlFlow::Continue(s) => s,
+            ControlFlow::Break(result) => return result,
+        };
 
         if state.startup_timed_out() {
             let detail = abort_process_child(&mut child, stderr_handle.take());
@@ -377,26 +433,16 @@ pub(super) fn run_process_driver(
         let observation = match recv_process_stream_observation(&stdout_rx, Some(recv_timeout)) {
             Ok(observation) => observation,
             Err(RecvTimeoutError::Timeout) => {
-                state = match maybe_process_driver_host_stop(
-                    state,
-                    &mut child,
-                    &mut stderr_handle,
-                    lifecycle,
-                )? {
-                    ControlFlow::Break(execution) => return Ok(execution),
-                    ControlFlow::Continue(state) => state,
+                state = match check_host_stop(state, &mut child, &mut stderr_handle, lifecycle) {
+                    ControlFlow::Continue(s) => s,
+                    ControlFlow::Break(result) => return result,
                 };
                 continue;
             }
             Err(RecvTimeoutError::Disconnected) => {
-                state = match maybe_process_driver_host_stop(
-                    state,
-                    &mut child,
-                    &mut stderr_handle,
-                    lifecycle,
-                )? {
-                    ControlFlow::Break(execution) => return Ok(execution),
-                    ControlFlow::Continue(state) => state,
+                state = match check_host_stop(state, &mut child, &mut stderr_handle, lifecycle) {
+                    ControlFlow::Continue(s) => s,
+                    ControlFlow::Break(result) => return result,
                 };
                 let detail = abort_process_child(&mut child, stderr_handle.take());
                 let message = if detail.is_empty() {
@@ -408,13 +454,9 @@ pub(super) fn run_process_driver(
                         "receive process driver stdout for {command_display}: stdout reader disconnected unexpectedly ({detail})"
                     )
                 };
-                return match state.commit_phase() {
-                    ProcessDriverCommitPhase::BeforeFirstCommittedStep => {
-                        Err(driver_io_error(message))
-                    }
-                    ProcessDriverCommitPhase::AfterFirstCommittedStep => Ok(state
-                        .into_execution(DriverTerminal::Interrupted(InterruptionReason::DriverIo))),
-                };
+                return state.into_terminal_failure(InterruptionReason::DriverIo, || {
+                    driver_io_error(message)
+                });
             }
         };
 
@@ -425,33 +467,22 @@ pub(super) fn run_process_driver(
                     Ok(message) => message,
                     Err(err) => {
                         let _detail = abort_process_child(&mut child, stderr_handle.take());
-                        return match state.commit_phase() {
-                            ProcessDriverCommitPhase::BeforeFirstCommittedStep => {
-                                Err(driver_protocol_json_error(
-                                    format!(
-                                        "process driver {command_display} emitted invalid JSONL protocol before first committed step: {err}"
-                                    ),
-                                    err,
-                                ))
-                            }
-                            ProcessDriverCommitPhase::AfterFirstCommittedStep => {
-                                Ok(state.into_execution(DriverTerminal::Interrupted(
-                                    InterruptionReason::ProtocolViolation,
-                                )))
-                            }
-                        };
+                        return state.into_terminal_failure(
+                            InterruptionReason::ProtocolViolation,
+                            || driver_protocol_json_error(
+                                format!(
+                                    "process driver {command_display} emitted invalid JSONL protocol before first committed step: {err}"
+                                ),
+                                err,
+                            ),
+                        );
                     }
                 }
             }
             ProcessDriverStreamObservation::Eof => {
-                state = match maybe_process_driver_host_stop(
-                    state,
-                    &mut child,
-                    &mut stderr_handle,
-                    lifecycle,
-                )? {
-                    ControlFlow::Break(execution) => return Ok(execution),
-                    ControlFlow::Continue(state) => state,
+                state = match check_host_stop(state, &mut child, &mut stderr_handle, lifecycle) {
+                    ControlFlow::Continue(s) => s,
+                    ControlFlow::Break(result) => return result,
                 };
                 let exit_status =
                     wait_for_child_exit(&mut child, process_policy).map_err(|err| {
@@ -478,40 +509,34 @@ pub(super) fn run_process_driver(
                     None => abort_process_child(&mut child, stderr_handle.take()),
                 };
 
-                if state.commit_phase() == ProcessDriverCommitPhase::BeforeFirstCommittedStep {
-                    let suffix = if detail.is_empty() {
-                        String::new()
-                    } else {
-                        format!(" ({detail})")
-                    };
-                    let message = match exit_status {
-                        Some(status) => format!(
-                            "process driver {command_display} ended before first committed step ({}){}",
-                            status,
-                            suffix
-                        ),
-                        None => format!(
-                            "process driver {command_display} closed stdout but did not exit within {}ms before first committed step{}",
-                            process_policy.termination_grace.as_millis(),
-                            suffix
-                        ),
-                    };
-                    return Err(driver_start_error(message));
-                }
-
-                return Ok(state.into_execution(DriverTerminal::Interrupted(
+                let suffix = if detail.is_empty() {
+                    String::new()
+                } else {
+                    format!(" ({detail})")
+                };
+                return state.into_terminal_failure(
                     InterruptionReason::DriverTerminated,
-                )));
+                    || {
+                        let message = match exit_status {
+                            Some(status) => format!(
+                                "process driver {command_display} ended before first committed step ({}){}",
+                                status,
+                                suffix
+                            ),
+                            None => format!(
+                                "process driver {command_display} closed stdout but did not exit within {}ms before first committed step{}",
+                                process_policy.termination_grace.as_millis(),
+                                suffix
+                            ),
+                        };
+                        driver_start_error(message)
+                    },
+                );
             }
             ProcessDriverStreamObservation::ReadError(failure) => {
-                state = match maybe_process_driver_host_stop(
-                    state,
-                    &mut child,
-                    &mut stderr_handle,
-                    lifecycle,
-                )? {
-                    ControlFlow::Break(execution) => return Ok(execution),
-                    ControlFlow::Continue(state) => state,
+                state = match check_host_stop(state, &mut child, &mut stderr_handle, lifecycle) {
+                    ControlFlow::Continue(s) => s,
+                    ControlFlow::Break(result) => return result,
                 };
                 let extra = abort_process_child(&mut child, stderr_handle.take());
                 match failure {
@@ -526,15 +551,10 @@ pub(super) fn run_process_driver(
                                 "process driver {command_display} emitted malformed protocol bytes: {detail} ({extra})"
                             )
                         };
-                        return match state.commit_phase() {
-                            ProcessDriverCommitPhase::BeforeFirstCommittedStep => {
-                                Err(driver_protocol_io_error(message, source))
-                            }
-                            ProcessDriverCommitPhase::AfterFirstCommittedStep => Ok(state
-                                .into_execution(DriverTerminal::Interrupted(
-                                    InterruptionReason::ProtocolViolation,
-                                ))),
-                        };
+                        return state
+                            .into_terminal_failure(InterruptionReason::ProtocolViolation, || {
+                                driver_protocol_io_error(message, source)
+                            });
                     }
                     ProcessDriverReadFailure::Io(source) => {
                         let detail = source.to_string();
@@ -545,15 +565,9 @@ pub(super) fn run_process_driver(
                                 "read process driver stdout for {command_display}: {detail} ({extra})"
                             )
                         };
-                        return match state.commit_phase() {
-                            ProcessDriverCommitPhase::BeforeFirstCommittedStep => {
-                                Err(driver_io_source_error(message, source))
-                            }
-                            ProcessDriverCommitPhase::AfterFirstCommittedStep => Ok(state
-                                .into_execution(DriverTerminal::Interrupted(
-                                    InterruptionReason::DriverIo,
-                                ))),
-                        };
+                        return state.into_terminal_failure(InterruptionReason::DriverIo, || {
+                            driver_io_source_error(message, source)
+                        });
                     }
                 }
             }
@@ -586,26 +600,22 @@ pub(super) fn run_process_driver(
         match message {
             ProcessDriverMessage::Hello { .. } => {
                 let _detail = abort_process_child(&mut child, stderr_handle.take());
-                if state.commit_phase() == ProcessDriverCommitPhase::BeforeFirstCommittedStep {
-                    return Err(driver_protocol_error(format!(
-                        "process driver {command_display} sent duplicate hello before first committed step"
-                    )));
-                }
-                return Ok(state.into_execution(DriverTerminal::Interrupted(
+                return state.into_terminal_failure(
                     InterruptionReason::ProtocolViolation,
-                )));
+                    || {
+                        driver_protocol_error(format!(
+                            "process driver {command_display} sent duplicate hello before first committed step"
+                        ))
+                    },
+                );
             }
             ProcessDriverMessage::Event { event } => match state.runner.step(event) {
                 Ok(_) => {
                     state.record_committed_event();
-                    state = match maybe_process_driver_host_stop(
-                        state,
-                        &mut child,
-                        &mut stderr_handle,
-                        lifecycle,
-                    )? {
-                        ControlFlow::Break(execution) => return Ok(execution),
-                        ControlFlow::Continue(state) => state,
+                    state = match check_host_stop(state, &mut child, &mut stderr_handle, lifecycle)
+                    {
+                        ControlFlow::Continue(s) => s,
+                        ControlFlow::Break(result) => return result,
                     };
                 }
                 Err(crate::HostedStepError::EgressDispatchFailure(failure)) => {

--- a/crates/prod/core/host/src/usecases/shared.rs
+++ b/crates/prod/core/host/src/usecases/shared.rs
@@ -1,28 +1,27 @@
 //! usecases shared
 //!
 //! Purpose:
-//! - Hold the private import/prelude authority for the host `usecases`
-//!   submodules and shared internal support types.
+//! - Shared external-crate and standard-library import prelude for the host
+//!   `usecases` submodules (`live_prep`, `live_run`, and the `usecases.rs`
+//!   facade).
 //!
 //! Owns:
-//! - The internal `use` surface consumed by `live_prep`, `live_run`,
-//!   `process_driver`, and the `usecases.rs` facade implementation.
+//! - The `pub(super)` re-export surface consumed via `use super::shared::*`
+//!   in sibling modules. Items here are external-crate types, std types, and
+//!   crate-internal re-exports that multiple siblings need.
 //!
 //! Does not own:
-//! - Public host API types or canonical orchestration entrypoints; those remain
-//!   in `usecases.rs`.
-//!
-//! Connects to:
-//! - `usecases.rs` as the parent facade implementation.
-//! - `live_prep.rs`, `live_run.rs`, and `process_driver.rs` as the private
-//!   execution submodules.
+//! - Public host API types (owned by `usecases.rs`).
+//! - Sibling-module types (imported explicitly between siblings).
+//! - Process-driver-only types (`process_driver.rs` imports directly).
 //!
 //! Safety notes:
-//! - This module exists specifically so the public facade is no longer the
-//!   de facto import authority for every child module.
-//! - Keep imports here narrowly aligned with real submodule needs; do not turn
-//!   this into a second semantic authority.
+//! - `process_driver.rs` imports all its dependencies explicitly and does NOT
+//!   use this prelude. Only `live_prep.rs` and `live_run.rs` consume it.
+//! - Keep imports here narrowly aligned with real multi-consumer needs; do not
+//!   add items used by only one sibling.
 
+// --- External crate types ---
 pub(super) use ergo_adapter::{
     adapter_fingerprint,
     fixture::{self, FixtureParseError},
@@ -50,21 +49,19 @@ pub(super) use ergo_supervisor::{
     write_capture_bundle, CaptureBundle, CaptureJsonStyle, CaptureWriteError, Constraints,
     NO_ADAPTER_PROVENANCE,
 };
-pub(super) use serde::{Deserialize, Serialize};
+
+// --- Standard library ---
 pub(super) use std::collections::{BTreeSet, HashMap, HashSet};
 pub(super) use std::fs;
-pub(super) use std::io::{BufRead, BufReader, Read};
 pub(super) use std::path::{Path, PathBuf};
-pub(super) use std::process::{Child, ChildStdout, Command, ExitStatus, Stdio};
 pub(super) use std::sync::atomic::{AtomicBool, Ordering};
-pub(super) use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 pub(super) use std::sync::Arc;
-pub(super) use std::thread::{self, JoinHandle};
 pub(super) use std::time::{Duration, Instant};
 
+// --- Crate-internal re-exports ---
 pub(super) use crate::egress::compute_egress_provenance;
 pub(super) use crate::{
     decision_counts, replay_bundle_strict, runner::validate_hosted_runner_configuration,
     EgressConfig, EgressDispatchFailure, HostedAdapterConfig, HostedEvent, HostedReplayError,
-    HostedRunner, HostedStepError, PROCESS_DRIVER_PROTOCOL_VERSION,
+    HostedRunner, HostedStepError,
 };

--- a/crates/prod/core/host/src/usecases/tests/mod.rs
+++ b/crates/prod/core/host/src/usecases/tests/mod.rs
@@ -37,6 +37,7 @@ use ergo_runtime::source::{
 };
 use serde_json::json;
 use std::collections::HashMap;
+use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;


### PR DESCRIPTION
## Summary

Clarifies ownership boundaries and phase authority across the host crate's execution pipeline.

## Changes

- **Separate warning emission from validation** via new diagnostics.rs module — validate_hosted_runner_configuration() is now pure, warning emission uses a writer-based seam
- **Move live-run setup DTO authority into live_prep.rs** — ValidatedLiveRunnerSetup and PreparedLiveRunnerSetup owned where they are constructed, fields private with into_parts() accessor
- **Introduce ValidatedDriverInput** for explicit driver-input phase boundary between preparation and execution
- **Centralize process-driver host-stop ownership** via explicit check_host_stop(...)
- **Replace generic capture-finalization transitions with domain-shaped methods** — on_step_success(), on_dispatch_failure(), on_fatal_error() replace open transition(to)
- **Tighten import authority and phase boundaries** across host usecases

## Verification

- cargo fmt --check ✅
- cargo test -p ergo-host: 208 passed, 0 failed ✅
- bash tools/verify_layer_boundaries.sh ✅

## Closes

Resolves #69, #72, #76, #77, #78
